### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+permissions:
+  contents: read
 #A workflow run is made up of one or more jobs. Jobs run in parallel by default.
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/Aniketkhote/getxify/security/code-scanning/1](https://github.com/Aniketkhote/getxify/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (right after `on` and before `jobs`) so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing behavior for checkout and test steps while enforcing least privilege for `GITHUB_TOKEN`. If Codecov later needs extra scopes in your environment, those can be added explicitly at job level, but do not grant write scopes unless required.

Change only `.github/workflows/main.yml` by inserting a root-level `permissions` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
