### PR TITLE
Enhance RxList, RxMap, and RxSet with mutation handling and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+## 4.1.0
+
+A single, narrow fix: an `RxList` built on a **fixed-length** list no longer throws when you change its length. Nothing that worked in 4.0.1 stops working, so this is a minor release.
+
+### Bug Fixes
+
+- **Fixed `Unsupported operation: Cannot add to a fixed-length list` on `RxList`** - the reported crash was `RxList<T> x = List<T>.empty().obs; x.insert(0, item);`, with a latent `x.clear()` (`Cannot clear a fixed-length list`) in the same app. `List.empty()` and `List.filled()` default to `growable: false`, so `List<T>.empty().obs` — a very common way to spell "an empty reactive list" — aliased a fixed-length backing that refused every length change. A fixed-length backing carries no *immutability intent*; the default is an accident of the `dart:core` API, not a decision the caller made. So the length-changing members now heal it: `add`, `addAll`, `insert`, `insertAll`, `remove`, `removeAt`, `removeLast`, `removeRange`, `removeWhere`, `retainWhere`, `replaceRange`, `clear`, `length=` and `operator +` transparently swap in a growable copy, apply the mutation there and notify listeners exactly once. This covers `List.empty()`, `List.filled()`, `List.of(..., growable: false)`, a `Uint8List` or any other typed-data list, and third-party fixed-length lists — the backing is classified by probing it, not by its type
+- **Fixed `RxList.shuffle()` notifying `2 * (length - 1)` times** - it was inherited from `ListMixin`, which swaps elements through `[]=`; it now delegates to the backing list and notifies exactly once, like every other mutator
+
+### Behavior Changes
+
+- **A length change on a fixed-length backing permanently detaches the `RxList` from it** - element writes (`[]=`, `sort`, `shuffle`, `setAll`, `setRange`, `fillRange`, `first=`, `last=`) still go straight through a fixed-length backing such as a `Uint8List`, and keep doing so for as long as the length never changes. The first `add`/`insert`/`remove`/`clear` swaps in a growable copy, and writes after that no longer reach the caller's buffer — including a length change that changes nothing, such as a `removeWhere` matching no element. If you need writes to keep reaching a fixed-length buffer, hold your own reference to it and avoid the length-changing members. The full aliasing contract is tabulated on the `RxList` class documentation
+- **A still-illegal length change on a fixed-length backing can report a different exception** - it now fails against the growable copy rather than against the backing, so `RxList<int>(List.filled(3, 0)).length = 5` throws `TypeError` (a non-nullable list cannot be padded with nulls) where it used to throw `UnsupportedError`. `catch`/`on UnsupportedError` sites around `RxList` length changes are worth a look
+- **`RxList.shuffle()` on a list of 0 or 1 elements notifies once, where it previously did not notify at all** - the inherited version performed no swaps and so emitted nothing. It still performs no swaps, and still does not touch the backing (so it does not throw on an unmodifiable one), but it does emit this override's single notification
+
+### Unchanged: unmodifiable collections are still unmodifiable
+
+An **unmodifiable** backing is the opposite of a fixed-length one: it is an explicit opt-in to immutability, and silently healing it would delete a guard the caller deliberately put in place, with no compile error to warn them. Nothing here changed in 4.1.0, and it is worth stating explicitly because the two shapes are easy to conflate:
+
+- `RxList.unmodifiable(...)`, `RxSet.unmodifiable(...)`, `RxMap.unmodifiable(...)`, `const [].obs`, `const <K, V>{}.obs`, `Map.unmodifiable({...}).obs`, `List.unmodifiable([...]).obs`, and an `UnmodifiableListView` or `UnmodifiableSetView` wrapped directly as a backing (`RxList(view)` / `RxSet(view)`) all still throw `UnsupportedError` from every mutator, keep their contents and notify nobody. The one collection that does *not* carry the opt-in over is `Set.obs`, which has always copied rather than aliased — see the note under Documentation
+- `RxSet` and `RxMap` are untouched apart from documentation. `dart:core` has no fixed-length-but-writable `Set` or `Map`, so "unmodifiable" was their only failure mode — there is nothing for them to heal
+- **The one documented exception is `assign` / `assignAll`**, on lists, sets and maps alike. They have replaced an unmodifiable backing with a fresh mutable collection since 4.0.0 and continue to. The resulting seam — `assignAll` succeeds on an unmodifiable backing where `add` throws — is intended, not an oversight: `assign`/`assignAll` *replace the contents wholesale*, so which collection object happened to be holding the old contents is an implementation detail with nothing left to protect, whereas `add`/`insert`/`clear` mutate a collection the caller declared unmodifiable
+- **Known limit of probing an *empty* backing.** With no element to attempt a write against, two empty shapes cannot be told apart from an empty fixed-length list, and both heal rather than throwing: a hand-rolled `ListBase` subclass that rejects mutation only through `length=`/`[]=`, and an unmodifiable typed-data view over a zero-length buffer (`Uint8List(0).asUnmodifiableView()`). Neither can hold data, so nothing is at risk of being overwritten. Every `dart:core` unmodifiable list is classified correctly whether empty or not, as is an unmodifiable typed-data view over a buffer with at least one byte in it
+
+### Internal Improvements
+
+- **Added `GetListenable.forceValue`** - a `@protected` counterpart to the `value` setter that skips its `==` short-circuit and then notifies exactly once, overridden in `RxObjectMixin` so it keeps the setter's disposal guard and stream bookkeeping. `RxList` uses it to publish the growable copy when it heals a fixed-length backing: the early return is right when an assignment replaces a *value*, but wrong when it replaces the *container*, because a `List` subclass with a content-insensitive `==` would make the setter silently drop the swap — and with it the mutation just applied to the copy — while still looking like it succeeded
+
+### Documentation
+
+- **Documented the three-way backing contract** - the `RxList` class documentation now tabulates growable / fixed-length / unmodifiable against element writes and length changes, spells out when the `RxList` detaches from the caller's list, and records the empty-backing limit above. `RxList.filled`/`empty`/`unmodifiable`, `RxSet.assign`/`assignAll` and `RxMap.assign` gained matching notes, including the copy fidelity `assign` offers (`toSet()` preserves the runtime element type and a `SplayTreeSet`'s comparator; `Map` has no `toMap()`, so an `RxMap` copy loses a `SplayTreeMap` comparator and `Map.identity()` semantics)
+- **Documented that `Set.obs` copies where `List.obs` and `Map.obs` alias** - long-standing behaviour, but it means `Set.unmodifiable({...}).obs` yields a fully mutable `RxSet` while the list and map equivalents keep rejecting mutation
+
+### Testing
+
+- **Added coverage for the narrow contract** - the reported crash, every `RxList` mutator over growable, fixed-length and unmodifiable backings, the notification counts on both the in-place and the heal path, the aliasing contract, state preservation when the action throws, the capability probes themselves (including backings that answer them with something other than `UnsupportedError`, and one whose `==` claims equality with any list), and equivalence against a plain `List`/`Set`/`Map` for the same call sequences. `flutter test` now runs 1272 tests
+
+---
+
 ## 4.0.1
 
 ### Bug Fixes

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -78,7 +78,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.1.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
+++ b/lib/get_rx/src/rx_types/rx_core/rx_impl.dart
@@ -86,6 +86,17 @@ mixin RxObjectMixin<T> on GetListenable<T> {
     super.value = val;
   }
 
+  /// Same as the [value] setter but without its `==` short-circuit — see
+  /// [GetListenable.forceValue]. Keeps the setter's disposal guard and stream
+  /// bookkeeping so the two stay interchangeable in every other respect.
+  @override
+  void forceValue(T val) {
+    if (isDisposed) return;
+    firstRebuild = false;
+    sentToStream = true;
+    super.forceValue(val);
+  }
+
   /// Returns a [StreamSubscription] similar to [listen], but with the
   /// added benefit that it primes the stream with the current [value], rather
   /// than waiting for the next [value]. This should not be called in [onInit]

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_list.dart
@@ -1,14 +1,119 @@
 part of '../rx_types.dart';
 
 /// Create a list similar to `List<T>` but reactive.
+///
+/// ## Healing a fixed-length backing list
+///
+/// An `RxList` wraps ("aliases") whatever list it is built from, so the
+/// backing list may well be one that refuses length changes. `List.empty()`
+/// and `List.filled()` are **fixed-length** by default, and
+/// `List<T>.empty().obs` is a very common way to spell "an empty reactive
+/// list" — after which the first `add`/`insert` used to blow up with
+/// `Unsupported operation: Cannot add to a fixed-length list` deep inside
+/// `dart:core`.
+///
+/// A fixed-length list carries no *immutability intent*: it is simply a list
+/// whose length happens to be fixed, and `growable: false` being the default
+/// on `List.empty()`/`List.filled()` is an accident of the `dart:core` API,
+/// not a decision the caller made. So a length-changing mutator on a
+/// fixed-length backing **heals**: the backing is transparently replaced with
+/// a growable copy, the mutation is applied to that copy, and listeners are
+/// notified exactly once.
+///
+/// An **unmodifiable** backing (`List.unmodifiable`, `const []`,
+/// `UnmodifiableListView`) is the opposite: it is an explicit opt-in to
+/// immutability. It is left alone. Every mutation still throws
+/// [UnsupportedError] from the backing itself, exactly as it always has —
+/// silently healing it would delete a guard the caller deliberately put in
+/// place, with no compile error to warn them.
+///
+/// ## The aliasing contract, precisely
+///
+/// | backing      | element write (`[]=`, `sort`, …) | length change (`add`, `clear`, …) |
+/// |--------------|----------------------------------|-----------------------------------|
+/// | growable     | in place, stays aliased          | in place, stays aliased           |
+/// | fixed-length | in place, stays aliased          | **heals** (detaches to a copy)    |
+/// | unmodifiable | **throws** `UnsupportedError`    | **throws** `UnsupportedError`     |
+///
+/// Three consequences to be aware of:
+///
+/// * A length change on a fixed-length backing **permanently** detaches this
+///   `RxList` from it — even one that changes nothing, such as a `removeWhere`
+///   that matches no element. Element writes made before that call landed in
+///   the caller's list; element writes made after it do not, because from then
+///   on the `RxList` owns a growable copy. If you need writes to keep reaching
+///   a fixed-length buffer (a `Uint8List`, say), keep a reference to it and
+///   never call a length-changing member on the `RxList`.
+/// * Healing changes which exception a still-illegal operation reports,
+///   because it now fails against the copy rather than against the backing:
+///   `RxList<int>(List.filled(3, 0)).length = 5` throws `TypeError` (you
+///   cannot pad a non-nullable list with nulls) where it used to throw
+///   `UnsupportedError`.
+/// * Element writes need no healing at all: a fixed-length list already
+///   accepts them in place, and an unmodifiable one already rejects them.
+///   They are plain in-place mutations followed by a single notification.
+///
+/// Two caveats on the "unmodifiable throws" row.
+///
+/// The first is `shuffle`: with fewer than two elements it has nothing to
+/// swap, so it returns without asking the backing to write anything and never
+/// reaches the point of being refused. That is what the inherited
+/// `ListMixin.shuffle` always did, and this class keeps it.
+///
+/// The second is that an *empty* backing cannot always be told apart from an
+/// empty fixed-length one, because there is no element to attempt a write
+/// against. Two empty shapes are therefore healed rather than honoured — a
+/// `ListBase` subclass that rejects mutation only through `length=`/`[]=`, and
+/// an unmodifiable typed-data view over a zero-length buffer
+/// (`Uint8List(0).asUnmodifiableView()`). Neither can hold data, so nothing is
+/// at risk of being overwritten. Every `dart:core` unmodifiable list is
+/// classified correctly whether empty or not, as is an unmodifiable
+/// typed-data view over a buffer with at least one byte in it.
+///
+/// ### The documented exception: `assign` / `assignAll`
+///
+/// [ListExtension.assign] and [ListExtension.assignAll] work over **any**
+/// backing, unmodifiable included — they publish a fresh growable list rather
+/// than mutating the current one. This is intentional, not an oversight: they
+/// *replace the contents wholesale*, so which list object happened to be
+/// holding the old contents is an implementation detail with nothing left to
+/// protect. `add`/`insert`/`clear`, by contrast, mutate a collection the
+/// caller declared unmodifiable, so they must keep throwing.
+///
+/// ## Note for implementors
+///
+/// The two capability probes ([_canChangeLength] and [_canWriteElements]) are
+/// deliberately different and the difference is load-bearing: together they
+/// tell *fixed-length* (heals) from *unmodifiable* (throws). Collapsing them
+/// into one probe would either heal unmodifiable backings or stop healing
+/// fixed-length ones. Please do not "optimise" them away.
+///
+/// Probing is itself a write (`length = length`, `list[0] = list[0]`), so a
+/// backing list that observes writes — one that logs, marks itself dirty or
+/// persists — sees extra no-op writes: one `length=` per length-changing call
+/// on a growable backing, plus one element write when that first probe fails.
+/// Element operations never probe. Nested `RxList` backings are
+/// short-circuited so they never see any of it.
 class RxList<E> extends GetListenable<List<E>>
     with ListMixin<E>, RxObjectMixin<List<E>> {
   RxList([List<E>? initial]) : super(initial ?? <E>[]);
 
+  /// Creates a list of the given [length] with [fill] at every position.
+  ///
+  /// With `growable: false` (the default) the backing list is fixed-length,
+  /// which carries no immutability intent: the first length-changing mutation
+  /// heals it by swapping in a growable copy, permanently detaching this
+  /// `RxList` from the fixed-length buffer. Element writes go to that buffer
+  /// in place until then. See the class documentation.
   factory RxList.filled(int length, E fill, {bool growable = false}) {
     return RxList(List.filled(length, fill, growable: growable));
   }
 
+  /// Creates an empty list.
+  ///
+  /// As with [RxList.filled], `growable: false` (the default) only picks a
+  /// fixed-length *initial* backing list — the returned [RxList] can still be
+  /// added to, and heals itself on the first `add`/`insert`/`clear`.
   factory RxList.empty({bool growable = false}) {
     return RxList(List.empty(growable: growable));
   }
@@ -33,8 +138,207 @@ class RxList<E> extends GetListenable<List<E>>
   }
 
   /// Creates an unmodifiable list containing all [elements].
+  ///
+  /// Unlike a fixed-length backing, an unmodifiable one is never healed: an
+  /// [RxList] built this way genuinely rejects mutation. `add`, `insert`,
+  /// `clear`, `[]=`, `sort` and friends all throw [UnsupportedError] from the
+  /// backing list, and the `RxList` is left untouched.
+  ///
+  /// The one documented exception is [ListExtension.assign] /
+  /// [ListExtension.assignAll], which replace the contents wholesale by
+  /// publishing a new growable backing list — see the class documentation for
+  /// why that is intended.
   factory RxList.unmodifiable(Iterable elements) {
     return RxList(List.unmodifiable(elements));
+  }
+
+  /// Whether [list] accepts length changes (`add`, `insert`, `remove`,
+  /// `clear`, `length=`, `replaceRange`).
+  ///
+  /// Probed rather than type-checked so third-party list implementations are
+  /// classified correctly too: `length = length` is a no-op on a growable
+  /// list and throws [UnsupportedError] on a fixed-length or unmodifiable
+  /// one. Only the probe is wrapped in a `catch` — never the real mutation,
+  /// whose [UnsupportedError]s (e.g. from a user callback) must propagate.
+  ///
+  /// The probe is *total*: any other error means "cannot classify", and the
+  /// answer is then `true`, which routes to the in-place branch — exactly what
+  /// happened before healing existed. A partial `ListBase` whose `length=`
+  /// throws a `StateError`/`UnimplementedError` but whose `add` works must not
+  /// be broken by a no-op write the caller never asked for.
+  ///
+  /// It does assume that a list which refuses length changes refuses this one
+  /// too. Every `dart:core` fixed-length list does — `FixedLengthListMixin`
+  /// rejects the setter outright, without looking at the value. A third-party
+  /// list that tolerates `length = length` while rejecting real length changes
+  /// would be classified growable and never heal; it would simply keep
+  /// throwing, as it did before healing existed.
+  static bool _canChangeLength<T>(List<T> list) {
+    // Short-circuit a nested RxList: probing through it would notify its own
+    // listeners for every mutation of the outer list. Claiming `true` is also
+    // the right answer — the inner RxList applies its own three-way policy to
+    // the action, healing or throwing exactly as it would on its own.
+    if (list is RxList) return true;
+    try {
+      list.length = list.length;
+      return true;
+    } on UnsupportedError {
+      return false;
+    } catch (_) {
+      return true;
+    }
+  }
+
+  /// Whether [list] accepts in-place element writes (`[]=`, `sort`,
+  /// `shuffle`, `setAll`, `setRange`, `fillRange`).
+  ///
+  /// This is strictly weaker than [_canChangeLength], and that gap is the
+  /// whole point of the probe: a *fixed-length* list happily overwrites its
+  /// elements, only an *unmodifiable* one refuses. So for a backing that has
+  /// already failed [_canChangeLength], this is what discriminates the two —
+  /// `true` means fixed-length (heal it), `false` means the caller opted into
+  /// immutability (let the backing throw). Element operations themselves
+  /// never consult it: they are plain in-place mutations, correct on both
+  /// kinds of backing without any help.
+  ///
+  /// Probed rather than type-checked, for the same reason as
+  /// [_canChangeLength], and with the same rule about the `catch`. This probe
+  /// is total too, but "cannot classify" answers `false` here: `false` routes
+  /// to the branch that runs the action straight against the backing, which is
+  /// the pre-healing behaviour that an unclassifiable backing should keep.
+  ///
+  /// ### The empty-list hole
+  ///
+  /// An empty list has no element to overwrite, so `[]=` cannot be probed and
+  /// the empty branch below stands in for it. That branch is exact for every
+  /// `dart:core` unmodifiable list and for typed-data views over a non-empty
+  /// buffer, but two shapes remain genuinely indistinguishable from an empty
+  /// fixed-length list, and both **heal**:
+  ///
+  /// * a `ListBase` subclass that rejects mutation only through `length=` and
+  ///   `[]=` — `ListMixin.setRange` returns early for a vacuous range without
+  ///   ever reaching `[]=`;
+  /// * an unmodifiable typed-data view over a zero-length buffer
+  ///   (`Uint8List(0).asUnmodifiableView()`) — there is no byte anywhere to
+  ///   attempt a write against.
+  ///
+  /// Neither can hold data, so nothing is at risk of being overwritten; the
+  /// cost is that an empty immutability marker is not honoured. Documented
+  /// rather than papered over — see the class documentation.
+  static bool _canWriteElements<T>(List<T> list) {
+    // Defensive: unreachable while [_canChangeLength] short-circuits a nested
+    // RxList to `true`, but it keeps the two probes independently correct.
+    if (list is RxList) return true;
+    if (list.isEmpty) {
+      // Typed data first: `_UnmodifiableUint8ArrayView` and friends only
+      // reject writes that actually touch an element, so they accept a vacuous
+      // `setRange` and the generic branch below would misread them as
+      // fixed-length. Their underlying buffer does not lie, so probe that
+      // instead — a no-op write of a byte back over itself, which leaves the
+      // buffer's contents untouched.
+      if (list is TypedData) {
+        try {
+          final bytes = (list as TypedData).buffer.asUint8List();
+          if (bytes.isNotEmpty) {
+            bytes[0] = bytes[0];
+            return true;
+          }
+          // Zero-length buffer: nothing to probe, and nothing to protect
+          // either. Heal, so that the common `RxList(Uint8List(0))` works and
+          // so that the answer is the same on the VM and on the web.
+          return true;
+        } on UnsupportedError {
+          return false;
+        } catch (_) {
+          return false;
+        }
+      }
+      // There is no element to overwrite, so `[]=` cannot be probed. This
+      // branch decides the fate of the single most common case there is —
+      // `List<T>.empty().obs` then `.add(...)` — so it has to be exactly
+      // right: a `dart:core` unmodifiable list throws even for a vacuous
+      // range, while a fixed-length one accepts it, which is precisely the
+      // distinction wanted. Answering `false` here (or falling back to
+      // [_canChangeLength], which is `false` for fixed-length too) would make
+      // `List.empty().obs.add(x)` throw again.
+      try {
+        list.setRange(0, 0, const []);
+        return true;
+      } on UnsupportedError {
+        return false;
+      } catch (_) {
+        return false;
+      }
+    }
+    try {
+      list[0] = list[0];
+      return true;
+    } on UnsupportedError {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Applies a length-changing [action] to the backing list. Three-way:
+  ///
+  /// * growable backing — mutate in place, notify once;
+  /// * fixed-length backing (refuses length changes but accepts element
+  ///   writes) — heal it: run [action] against a growable copy and publish
+  ///   that copy, notifying once;
+  /// * unmodifiable backing — run [action] straight against it so the
+  ///   backing's own [UnsupportedError] propagates untouched, leaving this
+  ///   `RxList` unchanged and un-notified.
+  R _mutateLength<R>(R Function(List<E> list) action) {
+    final current = value;
+    if (_canChangeLength(current)) {
+      final result = action(current);
+      refresh();
+      return result;
+    }
+    if (_canWriteElements(current)) {
+      // Fixed-length: no immutability intent, so heal it.
+      return _mutateCopy(current, action);
+    }
+    // Unmodifiable: an explicit opt-in to immutability. Do not synthesise or
+    // wrap an error — just perform the mutation and let the real one out. The
+    // refresh is for the (pathological) backing that refuses `length=` yet
+    // accepts this particular action; it keeps such a list behaving as it did
+    // before healing existed.
+    final result = action(current);
+    refresh();
+    return result;
+  }
+
+  /// Runs [action] on a growable copy of [current] and publishes the copy as
+  /// the new backing list, notifying listeners exactly once.
+  R _mutateCopy<R>(List<E> current, R Function(List<E> list) action) {
+    // toList() always returns a growable list, and reifies the *backing*
+    // list's runtime element type, so covariance keeps behaving as it did
+    // before the copy (this is what `assign`/`assignAll` rely on too).
+    final copy = current.toList();
+    // Run the action before publishing: if it throws (a RangeError, a
+    // TypeError, an exception from a user callback...) the copy is dropped
+    // and this RxList keeps its previous state.
+    final result = action(copy);
+    // [forceValue], never `value = copy`: the `value` setter short-circuits
+    // when the old backing reports itself `==` to the copy, and a `List`
+    // subclass with a content-insensitive `==` would then have the swap — and
+    // with it the mutation just applied to the copy — silently dropped while
+    // still looking like it succeeded. A backing replacement is not a value
+    // change, so the equality gate must not apply to it.
+    forceValue(copy);
+    // [forceValue] notifies exactly once, unless it refused the swap because
+    // this Rx is disposed. The backing is then still [current], so notify from
+    // here instead, like the in-place branch does — including the "used after
+    // dispose" assert it trips, which the in-place branch and RxSet/RxMap also
+    // trip.
+    //
+    // The test is `identical(value, current)`, never `!identical(value, copy)`:
+    // a listener that reassigns `value` while the notification is fanning out
+    // would make the latter true and notify a second time.
+    if (identical(value, current)) refresh();
+    return result;
   }
 
   @override
@@ -42,6 +346,8 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   void operator []=(int index, E val) {
+    // No healing: a fixed-length backing accepts element writes in place, an
+    // unmodifiable one throws on its own. See the class documentation.
     value[index] = val;
     refresh();
   }
@@ -61,33 +367,27 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   void add(E element) {
-    value.add(element);
-    refresh();
+    _mutateLength((list) => list.add(element));
   }
 
   @override
   void addAll(Iterable<E> iterable) {
-    value.addAll(iterable);
-    refresh();
+    _mutateLength((list) => list.addAll(iterable));
   }
 
   @override
   bool remove(Object? element) {
-    final removed = value.remove(element);
-    refresh();
-    return removed;
+    return _mutateLength((list) => list.remove(element));
   }
 
   @override
   void removeWhere(bool Function(E element) test) {
-    value.removeWhere(test);
-    refresh();
+    _mutateLength((list) => list.removeWhere(test));
   }
 
   @override
   void retainWhere(bool Function(E element) test) {
-    value.retainWhere(test);
-    refresh();
+    _mutateLength((list) => list.retainWhere(test));
   }
 
   @override
@@ -95,46 +395,37 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   set length(int newLength) {
-    value.length = newLength;
-    refresh();
+    _mutateLength((list) => list.length = newLength);
   }
 
   @override
   void clear() {
-    value.clear();
-    refresh();
+    _mutateLength((list) => list.clear());
   }
 
   @override
   E removeAt(int index) {
-    final result = value.removeAt(index);
-    refresh();
-    return result;
+    return _mutateLength((list) => list.removeAt(index));
   }
 
   @override
   E removeLast() {
-    final result = value.removeLast();
-    refresh();
-    return result;
+    return _mutateLength((list) => list.removeLast());
   }
 
   @override
   void removeRange(int start, int end) {
-    value.removeRange(start, end);
-    refresh();
+    _mutateLength((list) => list.removeRange(start, end));
   }
 
   @override
   void insert(int index, E element) {
-    value.insert(index, element);
-    refresh();
+    _mutateLength((list) => list.insert(index, element));
   }
 
   @override
   void insertAll(int index, Iterable<E> iterable) {
-    value.insertAll(index, iterable);
-    refresh();
+    _mutateLength((list) => list.insertAll(index, iterable));
   }
 
   @override
@@ -154,8 +445,10 @@ class RxList<E> extends GetListenable<List<E>>
 
   @override
   void replaceRange(int start, int end, Iterable<E> newContents) {
-    value.replaceRange(start, end, newContents);
-    refresh();
+    // On the length path even when `end - start == newContents.length`:
+    // FixedLengthListMixin.replaceRange rejects it unconditionally, with
+    // "Cannot remove from a fixed-length list". Verified, not assumed.
+    _mutateLength((list) => list.replaceRange(start, end, newContents));
   }
 
   @override
@@ -177,6 +470,31 @@ class RxList<E> extends GetListenable<List<E>>
   @override
   void sort([int Function(E a, E b)? compare]) {
     value.sort(compare);
+    refresh();
+  }
+
+  /// Overridden only to collapse the notifications: `ListMixin.shuffle`
+  /// swaps elements through `[]=`, which would notify `2 * (length - 1)`
+  /// times. Delegating to the backing list notifies once instead — and once
+  /// even for a list of 0 or 1 elements, where the inherited version made no
+  /// swaps and so notified not at all.
+  ///
+  /// [random] is intentionally left unannotated: this library does not import
+  /// `dart:math`, so `Random?` cannot be named here — override inference
+  /// copies the type straight from `ListMixin.shuffle`, keeping the public
+  /// signature identical.
+  @override
+  void shuffle([random]) {
+    // A list of 0 or 1 elements has nothing to swap. The inherited version
+    // returned without touching `[]=` at all, so it did not throw on an
+    // unmodifiable backing; `List.shuffle` does throw there, unconditionally.
+    // Return early to keep `const <T>[].obs.shuffle()` working as it always
+    // has, while still emitting this override's single notification.
+    if (value.length < 2) {
+      refresh();
+      return;
+    }
+    value.shuffle(random);
     refresh();
   }
 }

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_map.dart
@@ -137,6 +137,11 @@ extension MapExtension<K, V> on Map<K, V> {
   /// rather than mutated in place, so this works even when the map was
   /// created from an unmodifiable source (e.g. `const {}` or
   /// `Map.unmodifiable`), and listeners are notified exactly once.
+  ///
+  /// `Map` has no runtime-type-preserving copy the way [Iterable.toList] and
+  /// [Iterable.toSet] have, so the fresh map is a plain insertion-ordered map
+  /// parameterised by this map's own [K] and [V]: a `SplayTreeMap`'s
+  /// comparator and `Map.identity` semantics are not carried over.
   void assign(K key, V val) {
     if (this is RxMap<K, V>) {
       (this as RxMap<K, V>).value = <K, V>{key: val};

--- a/lib/get_rx/src/rx_types/rx_iterables/rx_set.dart
+++ b/lib/get_rx/src/rx_types/rx_iterables/rx_set.dart
@@ -113,6 +113,16 @@ class RxSet<E> extends GetListenable<Set<E>>
 }
 
 extension SetExtension<E> on Set<E> {
+  /// Wraps this set in an [RxSet].
+  ///
+  /// Unlike `List.obs` and `Map.obs`, which adopt the receiver as the backing
+  /// collection, this **copies** into a fresh mutable set. Long-standing
+  /// behaviour, kept for compatibility, but worth knowing: it means
+  /// `Set.unmodifiable({1, 2}).obs` and `const {1, 2}.obs` produce a fully
+  /// mutable [RxSet], where the list and map equivalents keep the caller's
+  /// unmodifiable collection and go on rejecting mutation. Wrap the receiver
+  /// explicitly — `RxSet(Set.unmodifiable({1, 2}))` — if you want the opt-in
+  /// carried over.
   RxSet<E> get obs {
     return RxSet<E>(<E>{})..addAll(this);
   }
@@ -135,11 +145,19 @@ extension SetExtension<E> on Set<E> {
   /// rather than mutated in place, so this works even when the set was
   /// created from an unmodifiable source (e.g. `const {}` or
   /// `Set.unmodifiable`), and listeners are notified exactly once.
+  ///
+  /// The copy is `toSet()` of the current backing, which always produces a
+  /// mutable set and preserves as much of the backing as the backing exposes:
+  /// its runtime element type always, and its ordering discipline only when
+  /// the backing has one to preserve — `UnmodifiableSetView.toSet()` forwards
+  /// to its source, so a view over a `SplayTreeSet` copies to a
+  /// `SplayTreeSet`, comparator included. `Set.unmodifiable` and `const {}`
+  /// forward too, but their source is already a plain insertion-ordered
+  /// `LinkedHashSet`, so the copy is one as well and later additions append
+  /// rather than sorting themselves in.
   void assign(E item) {
     if (this is RxSet) {
       final rx = this as RxSet;
-      // toSet() preserves the backing set's runtime element type while
-      // always producing a mutable copy.
       rx.value = rx.value.toSet()
         ..clear()
         ..add(item);
@@ -155,6 +173,8 @@ extension SetExtension<E> on Set<E> {
   /// rather than mutated in place, so this works even when the set was
   /// created from an unmodifiable source (e.g. `const {}` or
   /// `Set.unmodifiable`), and listeners are notified exactly once.
+  ///
+  /// The copy has the same fidelity as the one described on [assign].
   void assignAll(Iterable<E> items) {
     if (this is RxSet) {
       final rx = this as RxSet;

--- a/lib/get_rx/src/rx_types/rx_types.dart
+++ b/lib/get_rx/src/rx_types/rx_types.dart
@@ -2,6 +2,7 @@ library;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 

--- a/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_notifier.dart
@@ -204,6 +204,24 @@ class GetListenable<T> extends ListNotifierSingle implements RxInterface<T> {
     _notify();
   }
 
+  /// Replaces the held value **without** the `==` short-circuit that the
+  /// [value] setter applies, then notifies listeners exactly once.
+  ///
+  /// The setter's early return is right when the assignment replaces a
+  /// *value* — nothing observable changed, so nothing needs announcing. It is
+  /// wrong when the assignment replaces the *container*: `RxList` swapping a
+  /// fixed-length backing list for a growable copy, say. There the old
+  /// container may well report itself `==` to the copy (a `List` subclass with
+  /// a content-insensitive `==`), and honouring that would silently discard
+  /// the mutation just applied to the copy while still looking like it worked.
+  ///
+  /// Use [value] for value changes; this is only for backing replacement.
+  @protected
+  void forceValue(T newValue) {
+    _value = newValue;
+    _notify();
+  }
+
   /// Gets or sets the value when called as a function.
   T? call([T? v]) {
     if (v != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: getxify
 description: "An improved and enhanced version of GetX - Open screens/snackbars/dialogs without context, manage states and inject dependencies easily with GetXify."
-version: 4.0.1
+version: 4.1.0
 homepage: https://github.com/Aniketkhote/getxify
 repository: https://github.com/Aniketkhote/getxify
 issue_tracker: https://github.com/Aniketkhote/getxify/issues

--- a/test/rx/fixed_length_backing_mutators_test.dart
+++ b/test/rx/fixed_length_backing_mutators_test.dart
@@ -1,0 +1,1495 @@
+// Regression tests for the NARROW self-healing contract on RxList/RxSet/RxMap.
+//
+// Real-world trigger (production app, reported crash):
+//
+//     RxList<SaleRecDetail> mycartList = List<SaleRecDetail>.empty().obs;
+//     // ... on a button tap:
+//     mycartList.insert(0, newItem);
+//     // Unsupported operation: Cannot add to a fixed-length list
+//     //   #0 FixedLengthListMixin.insert (dart:_internal/list.dart:25:5)
+//     //   #1 RxList.insert (package:getxify/.../rx_iterables/rx_list.dart)
+//
+// `List.empty()` defaults to `growable: false`, so the RxList aliased a
+// fixed-length backing. The same app called `mycartList.clear()` elsewhere —
+// a second latent crash of the same family.
+//
+// The fix heals ONLY backings that carry no immutability intent:
+//
+//   * FIXED-LENGTH (`List.empty()`, `List.filled()`, a `Uint8List`, ...) — the
+//     length is fixed by accident of the `dart:core` API, not by a decision
+//     the caller made. A length-changing mutator transparently swaps in a
+//     growable copy, applies the mutation there and notifies EXACTLY ONCE.
+//     Element writes (`[]=`, `sort`, `setAll`, ...) need no help at all: a
+//     fixed-length list already accepts them in place, so the backing stays
+//     aliased.
+//
+//   * UNMODIFIABLE (`List.unmodifiable`, `const []`, `UnmodifiableListView`,
+//     `Set.unmodifiable`, `Map.unmodifiable`, `const {}`) — an EXPLICIT opt-in
+//     to immutability. Never healed. Every mutator still throws the backing's
+//     own `UnsupportedError`, the collection keeps its previous contents and
+//     no listener is notified. Silently swallowing that opt-in would delete a
+//     guard the caller deliberately put in place, with no compile error.
+//
+// RxSet and RxMap therefore have no healing whatsoever: `dart:core` has no
+// fixed-length-but-writable Set or Map, so "unmodifiable" was their only
+// failure mode and it is now an honoured opt-in again.
+//
+// The ONE documented exception is `assign`/`assignAll` (pinned by
+// fixed_length_backing_assign_test.dart, and by the "intended seam" group at
+// the bottom of this file): they replace the contents wholesale by publishing
+// a fresh mutable collection, so they work over any backing.
+import 'dart:collection';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getxify/getxify.dart';
+
+/// Stand-in for the model class from the crash report.
+class SaleRecDetail {
+  const SaleRecDetail(this.id);
+  final int id;
+}
+
+// ---------------------------------------------------------------------------
+// Backing shapes
+// ---------------------------------------------------------------------------
+
+/// Builds a backing collection holding exactly `seed`, or returns `null` when
+/// that shape cannot hold that seed (`List.empty()` is always empty, and a
+/// const literal cannot be built from a runtime value).
+typedef _ListBacking = List<int>? Function(List<int> seed);
+typedef _SetBacking = Set<int>? Function(Set<int> seed);
+typedef _MapBacking = Map<String, int>? Function(Map<String, int> seed);
+
+/// Const collections have to be written out, so they are looked up by seed.
+/// Every seed used in the matrices below has an entry here.
+const _constLists = <String, List<int>>{
+  '': <int>[],
+  '1,2,3': <int>[1, 2, 3],
+  '3,1,2': <int>[3, 1, 2],
+};
+const _constSets = <String, Set<int>>{
+  '': <int>{},
+  '1,2,3': <int>{1, 2, 3},
+};
+const _constMaps = <String, Map<String, int>>{
+  '': <String, int>{},
+  'a:1,b:2': <String, int>{'a': 1, 'b': 2},
+};
+
+String _key(Iterable<int> seed) => seed.join(',');
+String _mapKey(Map<String, int> seed) =>
+    seed.entries.map((e) => '${e.key}:${e.value}').join(',');
+
+/// Backings with no immutability intent. Length changes heal, element writes
+/// land in place.
+final Map<String, _ListBacking> _healingListBackings = <String, _ListBacking>{
+  // Control: the ordinary case, which must keep behaving exactly as before.
+  'a growable <int>[]': (seed) => <int>[...seed],
+  // The backing from the crash report.
+  'List.empty() (fixed-length)': (seed) =>
+      seed.isEmpty ? List<int>.empty() : null,
+  'List.filled (fixed-length)': (seed) =>
+      List<int>.filled(seed.length, 0)..setAll(0, seed),
+  // A fixed-length list that is not a `dart:core` growable list in disguise.
+  'a Uint8List (fixed-length)': (seed) => Uint8List.fromList(seed),
+};
+
+/// Backings that are an explicit opt-in to immutability. Nothing heals them.
+final Map<String, _ListBacking> _frozenListBackings = <String, _ListBacking>{
+  'List.unmodifiable': (seed) => List<int>.unmodifiable(seed),
+  'a const list literal': (seed) => _constLists[_key(seed)],
+  'UnmodifiableListView': (seed) => UnmodifiableListView<int>(<int>[...seed]),
+};
+
+final Map<String, _SetBacking> _mutableSetBackings = <String, _SetBacking>{
+  'a mutable <int>{}': (seed) => <int>{...seed},
+};
+
+final Map<String, _SetBacking> _frozenSetBackings = <String, _SetBacking>{
+  'Set.unmodifiable': (seed) => Set<int>.unmodifiable(seed),
+  'a const set literal': (seed) => _constSets[_key(seed)],
+  'UnmodifiableSetView': (seed) => UnmodifiableSetView<int>(<int>{...seed}),
+};
+
+final Map<String, _MapBacking> _mutableMapBackings = <String, _MapBacking>{
+  'a mutable <String, int>{}': (seed) => <String, int>{...seed},
+};
+
+final Map<String, _MapBacking> _frozenMapBackings = <String, _MapBacking>{
+  'Map.unmodifiable': (seed) => Map<String, int>.unmodifiable(seed),
+  'a const map literal': (seed) => _constMaps[_mapKey(seed)],
+  'UnmodifiableMapView': (seed) =>
+      UnmodifiableMapView<String, int>(<String, int>{...seed}),
+};
+
+// ---------------------------------------------------------------------------
+// Mutator cases
+// ---------------------------------------------------------------------------
+
+class _ListCase {
+  const _ListCase(
+    this.name,
+    this.seed,
+    this.apply,
+    this.expected, {
+    this.throwsOnFrozen = true,
+  });
+  final String name;
+  final List<int> seed;
+  final void Function(RxList<int> list) apply;
+  final Matcher expected;
+
+  /// Whether this mutator throws when the backing is unmodifiable.
+  ///
+  /// True for every mutator but one: `shuffle` on a list of fewer than two
+  /// elements has nothing to swap, so it returns without ever asking the
+  /// backing to write anything — exactly as the inherited `ListMixin.shuffle`
+  /// did before `RxList` overrode it to collapse the notifications. Making it
+  /// throw would be a regression against an unmodifiable backing, which the
+  /// narrow contract promises to leave behaving as it always has.
+  final bool throwsOnFrozen;
+}
+
+class _SetCase {
+  const _SetCase(
+    this.name,
+    this.seed,
+    this.apply,
+    this.expected, [
+    this.notifications = 1,
+  ]);
+  final String name;
+  final Set<int> seed;
+  final void Function(RxSet<int> set) apply;
+  final Matcher expected;
+  final int notifications;
+}
+
+class _MapCase {
+  const _MapCase(
+    this.name,
+    this.seed,
+    this.apply,
+    this.expected, [
+    this.notifications = 1,
+  ]);
+  final String name;
+  final Map<String, int> seed;
+  final void Function(RxMap<String, int> map) apply;
+  final Matcher expected;
+  final int notifications;
+}
+
+const _seed = <int>[1, 2, 3];
+const _sortSeed = <int>[3, 1, 2];
+const _noSeed = <int>[];
+
+/// Every `RxList` mutator, over a non-empty backing.
+final List<_ListCase> _seededListCases = <_ListCase>[
+  _ListCase('add', _seed, (l) => l.add(4), equals([1, 2, 3, 4])),
+  _ListCase('addAll', _seed, (l) => l.addAll([4, 5]), equals([1, 2, 3, 4, 5])),
+  _ListCase('insert', _seed, (l) => l.insert(0, 0), equals([0, 1, 2, 3])),
+  _ListCase(
+    'insertAll',
+    _seed,
+    (l) => l.insertAll(1, [8, 9]),
+    equals([1, 8, 9, 2, 3]),
+  ),
+  _ListCase('remove', _seed, (l) {
+    expect(l.remove(2), isTrue);
+  }, equals([1, 3])),
+  _ListCase('removeAt', _seed, (l) {
+    expect(l.removeAt(0), 1);
+  }, equals([2, 3])),
+  _ListCase('removeLast', _seed, (l) {
+    expect(l.removeLast(), 3);
+  }, equals([1, 2])),
+  _ListCase('removeRange', _seed, (l) => l.removeRange(0, 2), equals([3])),
+  _ListCase(
+    'removeWhere',
+    _seed,
+    (l) => l.removeWhere((e) => e.isEven),
+    equals([1, 3]),
+  ),
+  _ListCase(
+    'retainWhere',
+    _seed,
+    (l) => l.retainWhere((e) => e.isOdd),
+    equals([1, 3]),
+  ),
+  _ListCase('clear', _seed, (l) => l.clear(), isEmpty),
+  _ListCase('length= (shrink)', _seed, (l) => l.length = 1, equals([1])),
+  _ListCase('operator []=', _seed, (l) => l[1] = 9, equals([1, 9, 3])),
+  _ListCase('operator +', _seed, (l) {
+    // Unlike List.+, RxList.+ mutates in place and returns itself.
+    expect(identical(l + <int>[4], l), isTrue);
+  }, equals([1, 2, 3, 4])),
+  _ListCase('setAll', _seed, (l) => l.setAll(1, [8, 9]), equals([1, 8, 9])),
+  _ListCase(
+    'setRange',
+    _seed,
+    (l) => l.setRange(0, 2, [7, 8]),
+    equals([7, 8, 3]),
+  ),
+  _ListCase('fillRange', _seed, (l) => l.fillRange(0, 2, 0), equals([0, 0, 3])),
+  _ListCase(
+    'replaceRange',
+    _seed,
+    (l) => l.replaceRange(1, 3, [9]),
+    equals([1, 9]),
+  ),
+  _ListCase('sort', _sortSeed, (l) => l.sort(), equals([1, 2, 3])),
+  _ListCase(
+    'sort (custom comparator)',
+    _sortSeed,
+    (l) => l.sort((a, b) => b.compareTo(a)),
+    equals([3, 2, 1]),
+  ),
+  _ListCase(
+    'shuffle',
+    _seed,
+    (l) => l.shuffle(),
+    unorderedEquals(<int>[1, 2, 3]),
+  ),
+  _ListCase('first=', _seed, (l) => l.first = 9, equals([9, 2, 3])),
+  _ListCase('last=', _seed, (l) => l.last = 9, equals([1, 2, 9])),
+  _ListCase('addIf', _seed, (l) => l.addIf(true, 4), equals([1, 2, 3, 4])),
+  _ListCase(
+    'addAllIf',
+    _seed,
+    (l) => l.addAllIf(true, [4, 5]),
+    equals([1, 2, 3, 4, 5]),
+  ),
+  _ListCase('addNonNull', _seed, (l) => l.addNonNull(4), equals([1, 2, 3, 4])),
+];
+
+/// The same surface over an EMPTY backing — the only way `List.empty()`, the
+/// backing from the crash report, can be exercised. Mutators that need an
+/// existing element (`removeAt`, `removeLast`, `[]=`, `first=`, `last=`) are
+/// covered by [_seededListCases] instead.
+final List<_ListCase> _emptyListCases = <_ListCase>[
+  _ListCase('add', _noSeed, (l) => l.add(1), equals([1])),
+  _ListCase('addAll', _noSeed, (l) => l.addAll([1, 2]), equals([1, 2])),
+  _ListCase('insert', _noSeed, (l) => l.insert(0, 1), equals([1])),
+  _ListCase(
+    'insertAll',
+    _noSeed,
+    (l) => l.insertAll(0, [1, 2]),
+    equals([1, 2]),
+  ),
+  _ListCase('remove (absent)', _noSeed, (l) {
+    expect(l.remove(9), isFalse);
+  }, isEmpty),
+  _ListCase('removeWhere', _noSeed, (l) => l.removeWhere((e) => true), isEmpty),
+  _ListCase('retainWhere', _noSeed, (l) => l.retainWhere((e) => true), isEmpty),
+  _ListCase('clear', _noSeed, (l) => l.clear(), isEmpty),
+  _ListCase('length= (0)', _noSeed, (l) => l.length = 0, isEmpty),
+  _ListCase('operator +', _noSeed, (l) {
+    expect(identical(l + <int>[1], l), isTrue);
+  }, equals([1])),
+  _ListCase(
+    'setAll (vacuous)',
+    _noSeed,
+    (l) => l.setAll(0, const <int>[]),
+    isEmpty,
+  ),
+  _ListCase(
+    'setRange (vacuous)',
+    _noSeed,
+    (l) => l.setRange(0, 0, const <int>[]),
+    isEmpty,
+  ),
+  // A fill value is required even for an empty range: dart:core casts it to E
+  // before looking at the range, so `fillRange(0, 0)` on a List<int> is a
+  // TypeError with or without an RxList in the picture.
+  _ListCase(
+    'fillRange (vacuous)',
+    _noSeed,
+    (l) => l.fillRange(0, 0, 0),
+    isEmpty,
+  ),
+  _ListCase(
+    'removeRange (vacuous)',
+    _noSeed,
+    (l) => l.removeRange(0, 0),
+    isEmpty,
+  ),
+  _ListCase(
+    'replaceRange',
+    _noSeed,
+    (l) => l.replaceRange(0, 0, [9]),
+    equals([9]),
+  ),
+  _ListCase('sort', _noSeed, (l) => l.sort(), isEmpty),
+  // Nothing to swap, so it never reaches the backing — see [throwsOnFrozen].
+  _ListCase(
+    'shuffle',
+    _noSeed,
+    (l) => l.shuffle(),
+    isEmpty,
+    throwsOnFrozen: false,
+  ),
+  _ListCase('addIf', _noSeed, (l) => l.addIf(true, 1), equals([1])),
+  _ListCase(
+    'addAllIf',
+    _noSeed,
+    (l) => l.addAllIf(true, [1, 2]),
+    equals([1, 2]),
+  ),
+  _ListCase('addNonNull', _noSeed, (l) => l.addNonNull(1), equals([1])),
+];
+
+const _setSeed = <int>{1, 2, 3};
+const _noSetSeed = <int>{};
+
+final List<_SetCase> _setCases = <_SetCase>[
+  _SetCase('add', _setSeed, (s) {
+    expect(s.add(4), isTrue);
+  }, unorderedEquals(<int>[1, 2, 3, 4])),
+  // add/remove only notify when the set really changed.
+  _SetCase(
+    'add (already present)',
+    _setSeed,
+    (s) {
+      expect(s.add(2), isFalse);
+    },
+    unorderedEquals(<int>[1, 2, 3]),
+    0,
+  ),
+  _SetCase(
+    'addAll',
+    _setSeed,
+    (s) => s.addAll({4, 5}),
+    unorderedEquals(<int>[1, 2, 3, 4, 5]),
+  ),
+  _SetCase(
+    'addAll (vacuous)',
+    _setSeed,
+    (s) => s.addAll(const <int>[]),
+    unorderedEquals(<int>[1, 2, 3]),
+  ),
+  _SetCase('remove', _setSeed, (s) {
+    expect(s.remove(2), isTrue);
+  }, unorderedEquals(<int>[1, 3])),
+  _SetCase(
+    'remove (absent)',
+    _setSeed,
+    (s) {
+      expect(s.remove(9), isFalse);
+    },
+    unorderedEquals(<int>[1, 2, 3]),
+    0,
+  ),
+  _SetCase(
+    'removeAll',
+    _setSeed,
+    (s) => s.removeAll([1, 2]),
+    unorderedEquals(<int>[3]),
+  ),
+  _SetCase(
+    'retainAll',
+    _setSeed,
+    (s) => s.retainAll([2]),
+    unorderedEquals(<int>[2]),
+  ),
+  _SetCase(
+    'removeWhere',
+    _setSeed,
+    (s) => s.removeWhere((e) => e.isEven),
+    unorderedEquals(<int>[1, 3]),
+  ),
+  _SetCase(
+    'retainWhere',
+    _setSeed,
+    (s) => s.retainWhere((e) => e.isOdd),
+    unorderedEquals(<int>[1, 3]),
+  ),
+  _SetCase('clear', _setSeed, (s) => s.clear(), isEmpty),
+  // `update` hands `fn` the REAL backing set, so an unmodifiable backing
+  // throws from inside the callback (see the frozen matrix below).
+  _SetCase(
+    'update',
+    _setSeed,
+    (s) => s.update((v) => (v! as Set<int>).add(4)),
+    unorderedEquals(<int>[1, 2, 3, 4]),
+  ),
+  _SetCase('operator +', _setSeed, (s) {
+    expect(identical(s + {4}, s), isTrue);
+  }, unorderedEquals(<int>[1, 2, 3, 4])),
+  _SetCase(
+    'addIf',
+    _setSeed,
+    (s) => s.addIf(true, 4),
+    unorderedEquals(<int>[1, 2, 3, 4]),
+  ),
+  _SetCase(
+    'addAllIf',
+    _setSeed,
+    (s) => s.addAllIf(true, {4, 5}),
+    unorderedEquals(<int>[1, 2, 3, 4, 5]),
+  ),
+  _SetCase('add (empty backing)', _noSetSeed, (s) {
+    expect(s.add(1), isTrue);
+  }, unorderedEquals(<int>[1])),
+  _SetCase(
+    'addAll (empty backing)',
+    _noSetSeed,
+    (s) => s.addAll({1, 2}),
+    unorderedEquals(<int>[1, 2]),
+  ),
+  _SetCase('clear (empty backing)', _noSetSeed, (s) => s.clear(), isEmpty),
+];
+
+const _mapSeed = <String, int>{'a': 1, 'b': 2};
+const _noMapSeed = <String, int>{};
+
+final List<_MapCase> _mapCases = <_MapCase>[
+  _MapCase(
+    'operator []= (new key)',
+    _mapSeed,
+    (m) => m['c'] = 3,
+    equals({'a': 1, 'b': 2, 'c': 3}),
+  ),
+  _MapCase(
+    'operator []= (existing key)',
+    _mapSeed,
+    (m) => m['a'] = 9,
+    equals({'a': 9, 'b': 2}),
+  ),
+  _MapCase(
+    'addAll',
+    _mapSeed,
+    (m) => m.addAll({'c': 3}),
+    equals({'a': 1, 'b': 2, 'c': 3}),
+  ),
+  _MapCase(
+    'addAll (vacuous)',
+    _mapSeed,
+    (m) => m.addAll(const <String, int>{}),
+    equals({'a': 1, 'b': 2}),
+  ),
+  _MapCase(
+    'addEntries',
+    _mapSeed,
+    (m) => m.addEntries([const MapEntry('c', 3)]),
+    equals({'a': 1, 'b': 2, 'c': 3}),
+  ),
+  _MapCase('putIfAbsent (absent)', _mapSeed, (m) {
+    expect(m.putIfAbsent('c', () => 3), 3);
+  }, equals({'a': 1, 'b': 2, 'c': 3})),
+  // The only Map mutator that can leave the map untouched, so the only one
+  // that must skip the notification.
+  _MapCase(
+    'putIfAbsent (present)',
+    _mapSeed,
+    (m) {
+      expect(m.putIfAbsent('a', () => 99), 1);
+    },
+    equals({'a': 1, 'b': 2}),
+    0,
+  ),
+  _MapCase('update', _mapSeed, (m) {
+    expect(m.update('a', (v) => v + 10), 11);
+  }, equals({'a': 11, 'b': 2})),
+  _MapCase('update (ifAbsent)', _mapSeed, (m) {
+    expect(m.update('z', (v) => v, ifAbsent: () => 7), 7);
+  }, equals({'a': 1, 'b': 2, 'z': 7})),
+  _MapCase(
+    'updateAll',
+    _mapSeed,
+    (m) => m.updateAll((k, v) => v * 10),
+    equals({'a': 10, 'b': 20}),
+  ),
+  _MapCase('remove', _mapSeed, (m) {
+    expect(m.remove('a'), 1);
+  }, equals({'b': 2})),
+  // Unlike Set.remove, Map.remove notifies even when nothing was removed —
+  // long-standing behaviour that none of this work changes.
+  _MapCase('remove (absent)', _mapSeed, (m) {
+    expect(m.remove('z'), isNull);
+  }, equals({'a': 1, 'b': 2})),
+  _MapCase(
+    'removeWhere',
+    _mapSeed,
+    (m) => m.removeWhere((k, v) => v.isEven),
+    equals({'a': 1}),
+  ),
+  _MapCase('clear', _mapSeed, (m) => m.clear(), isEmpty),
+  _MapCase(
+    'addIf',
+    _mapSeed,
+    (m) => m.addIf(true, 'c', 3),
+    equals({'a': 1, 'b': 2, 'c': 3}),
+  ),
+  _MapCase(
+    'addAllIf',
+    _mapSeed,
+    (m) => m.addAllIf(true, {'c': 3}),
+    equals({'a': 1, 'b': 2, 'c': 3}),
+  ),
+  _MapCase(
+    'operator []= (empty backing)',
+    _noMapSeed,
+    (m) => m['a'] = 1,
+    equals({'a': 1}),
+  ),
+  _MapCase(
+    'addAll (empty backing)',
+    _noMapSeed,
+    (m) => m.addAll({'a': 1}),
+    equals({'a': 1}),
+  ),
+  _MapCase('clear (empty backing)', _noMapSeed, (m) => m.clear(), isEmpty),
+];
+
+void main() {
+  // -------------------------------------------------------------------------
+  group('the reported crash', () {
+    test('insert into List.empty().obs, then clear, then add again', () async {
+      // Verbatim shape of the production code that crashed.
+      final RxList<SaleRecDetail> mycartList = List<SaleRecDetail>.empty().obs;
+      var notifications = 0;
+      mycartList.listen((_) => notifications++);
+
+      // Used to throw: Unsupported operation: Cannot add to a fixed-length
+      // list.
+      mycartList.insert(0, const SaleRecDetail(1));
+      mycartList.insert(0, const SaleRecDetail(2));
+      expect(mycartList.map((e) => e.id), [2, 1]);
+
+      // The second latent crash in the same app.
+      mycartList.clear();
+      expect(mycartList, isEmpty);
+
+      mycartList.add(const SaleRecDetail(3));
+      expect(mycartList.map((e) => e.id), [3]);
+
+      await Future.delayed(Duration.zero);
+      expect(notifications, 4);
+    });
+
+    test('a const list literal .obs is NOT healed', () {
+      // ListExtension.obs adopts the receiver, so this really does wrap a
+      // const (unmodifiable) list. Unlike `List.empty()`, a const literal is
+      // an explicit statement that the contents must not change, so it keeps
+      // throwing instead of quietly detaching.
+      final RxList<int> list = const <int>[1].obs;
+
+      expect(() => list.add(2), throwsUnsupportedError);
+      expect(list, [1]);
+    });
+
+    test('a const map literal .obs is NOT healed', () {
+      // MapExtension.obs adopts the receiver too, so this wraps a const
+      // (unmodifiable) map. Same reasoning as above.
+      final RxMap<String, int> map = const <String, int>{'a': 1}.obs;
+
+      expect(() => map['b'] = 2, throwsUnsupportedError);
+      expect(map, {'a': 1});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RxList over a backing with NO immutability intent: every mutator works,
+  // notifying exactly once.
+  // -------------------------------------------------------------------------
+  for (final backing in _healingListBackings.entries) {
+    for (final cases in <List<_ListCase>>[_seededListCases, _emptyListCases]) {
+      final label = identical(cases, _emptyListCases) ? ', empty' : '';
+      group('RxList over ${backing.key}$label', () {
+        for (final c in cases) {
+          if (backing.value(c.seed) == null) continue;
+          test('${c.name} works and notifies exactly once', () async {
+            final list = RxList<int>(backing.value(c.seed)!);
+            var notifications = 0;
+            list.listen((_) => notifications++);
+
+            c.apply(list);
+            await Future.delayed(Duration.zero);
+
+            expect(list, c.expected);
+            expect(notifications, 1);
+          });
+        }
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // RxList over an UNMODIFIABLE backing: every mutator throws, nothing is
+  // healed, no listener is notified. This is the inverse of the matrix above
+  // and is the whole point of the narrow contract.
+  // -------------------------------------------------------------------------
+  for (final backing in _frozenListBackings.entries) {
+    for (final cases in <List<_ListCase>>[_seededListCases, _emptyListCases]) {
+      final label = identical(cases, _emptyListCases) ? ', empty' : '';
+      group('RxList over ${backing.key}$label', () {
+        for (final c in cases) {
+          if (backing.value(c.seed) == null) continue;
+          if (!c.throwsOnFrozen) {
+            test('${c.name} is a no-op, exactly as it always was', () async {
+              final source = backing.value(c.seed)!;
+              final list = RxList<int>(source);
+              var notifications = 0;
+              list.listen((_) => notifications++);
+
+              // It never asks the backing to write, so there is nothing for
+              // the backing to refuse — and it must not start refusing now.
+              expect(() => c.apply(list), returnsNormally);
+              await Future.delayed(Duration.zero);
+
+              expect(list, equals(c.seed));
+              expect(
+                identical(list.value, source),
+                isTrue,
+                reason: 'an unmodifiable backing is never swapped out',
+              );
+              expect(
+                notifications,
+                1,
+                reason: 'every mutator call notifies exactly once',
+              );
+            });
+            continue;
+          }
+          test(
+            '${c.name} throws UnsupportedError and changes nothing',
+            () async {
+              final source = backing.value(c.seed)!;
+              final list = RxList<int>(source);
+              var notifications = 0;
+              list.listen((_) => notifications++);
+
+              expect(() => c.apply(list), throwsUnsupportedError);
+              await Future.delayed(Duration.zero);
+
+              expect(list, equals(c.seed));
+              expect(
+                identical(list.value, source),
+                isTrue,
+                reason: 'an unmodifiable backing is never swapped out',
+              );
+              expect(notifications, 0);
+            },
+          );
+        }
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  group('RxList backing-swap behaviour', () {
+    test('a rejected mutation replaces the backing exactly once', () {
+      final list = RxList<int>(List<int>.empty());
+
+      list.add(1);
+      final healed = list.value;
+      expect(healed, isNot(isEmpty));
+
+      // Every later mutation must reuse the growable copy, not build another.
+      list.add(2);
+      list.insert(0, 0);
+      list.removeAt(1);
+
+      expect(identical(list.value, healed), isTrue);
+      expect(list, [0, 2]);
+    });
+
+    test('the heal path never mutates the original fixed-length buffer', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final list = RxList<int>(backing);
+
+      list.add(4);
+
+      expect(backing, [1, 2, 3]);
+      expect(list, [1, 2, 3, 4]);
+      expect(identical(list.value, backing), isFalse);
+    });
+
+    test('a growable backing is still mutated in place (aliasing kept)', () {
+      final backing = <int>[1, 2];
+      final list = RxList<int>(backing);
+
+      list.add(3);
+      list.insert(0, 0);
+
+      expect(backing, [0, 1, 2, 3]);
+      expect(identical(list.value, backing), isTrue);
+    });
+
+    test('element writes go straight through a fixed-length backing', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final list = RxList<int>(backing);
+
+      list[1] = 9;
+      list.first = 8;
+      list.last = 7;
+      list.fillRange(1, 2, 5);
+      list.setAll(0, [4]);
+      list.setRange(1, 3, [5, 6]);
+
+      expect(identical(list.value, backing), isTrue);
+      expect(backing, [4, 5, 6]);
+    });
+
+    test('element writes reach a Uint8List backing in place', () {
+      // The case the aliasing contract exists for: a typed buffer the caller
+      // still holds a reference to.
+      final backing = Uint8List.fromList([1, 2, 3]);
+      final list = RxList<int>(backing);
+
+      list[0] = 9;
+      list.sort();
+      list.setRange(0, 2, [4, 5]);
+
+      expect(identical(list.value, backing), isTrue);
+      expect(backing, [4, 5, 9]);
+    });
+
+    test('sort mutates a fixed-length backing in place (no copy path)', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [3, 1, 2]);
+      final list = RxList<int>(backing);
+
+      list.sort();
+
+      expect(
+        identical(list.value, backing),
+        isTrue,
+        reason:
+            'a fixed-length list accepts element writes, so sorting it '
+            'must not detach the backing',
+      );
+      expect(backing, [1, 2, 3]);
+    });
+
+    test('sort on an unmodifiable backing throws and changes nothing', () {
+      final backing = List<int>.unmodifiable([3, 1, 2]);
+      final list = RxList<int>(backing);
+
+      expect(() => list.sort(), throwsUnsupportedError);
+
+      expect(identical(list.value, backing), isTrue);
+      expect(backing, [3, 1, 2], reason: 'the original is left alone');
+      expect(list, [3, 1, 2]);
+    });
+
+    test('shuffle on a fixed-length backing shuffles it in place', () {
+      final backing = List<int>.filled(5, 0)..setAll(0, [1, 2, 3, 4, 5]);
+      final list = RxList<int>(backing);
+
+      list.shuffle();
+
+      expect(identical(list.value, backing), isTrue);
+      expect(list, unorderedEquals(<int>[1, 2, 3, 4, 5]));
+    });
+
+    test('the growable copy keeps the runtime element type of the backing', () {
+      final RxList<num> list = RxList<num>(
+        List<int>.filled(2, 0)..setAll(0, [1, 2]),
+      );
+
+      // The copy is built with toList(), so it is still a List<int> and keeps
+      // rejecting incompatible elements — same contract as assignAll.
+      list.add(3);
+      expect(list, [1, 2, 3]);
+      expect(() => list.add(0.5), throwsA(isA<TypeError>()));
+    });
+
+    test('RxList.filled/empty with growable: false are healed on add', () {
+      final filled = RxList<int>.filled(2, 7);
+      final empty = RxList<int>.empty();
+
+      filled.add(8);
+      empty.add(1);
+
+      expect(filled, [7, 7, 8]);
+      expect(empty, [1]);
+    });
+
+    test('length= can grow a fixed-length backing of a nullable type', () {
+      final list = RxList<int?>(List<int?>.filled(2, 0));
+
+      list.length = 4;
+
+      expect(list, [0, 0, null, null]);
+    });
+
+    test('growing a non-nullable list still throws, on every backing', () {
+      // Unchanged pre-existing behaviour: filling with nulls is a type error,
+      // which is orthogonal to whether the backing accepts length changes.
+      expect(() => RxList<int>(<int>[1]).length = 3, throwsA(isA<TypeError>()));
+      expect(
+        () => RxList<int>(List<int>.filled(1, 0)).length = 3,
+        throwsA(isA<TypeError>()),
+      );
+    });
+
+    test('probing does not notify a nested RxList backing', () async {
+      final inner = RxList<int>(<int>[1, 2]);
+      final outer = RxList<int>(inner);
+      var innerNotifications = 0;
+      var outerNotifications = 0;
+      inner.listen((_) => innerNotifications++);
+      outer.listen((_) => outerNotifications++);
+
+      outer.add(3);
+      await Future.delayed(Duration.zero);
+
+      expect(outer, [1, 2, 3]);
+      expect(outerNotifications, 1);
+      expect(
+        innerNotifications,
+        1,
+        reason: 'only the real mutation, never the capability probe',
+      );
+    });
+
+    test('a nested RxList backing applies its OWN policy', () {
+      // The outer list short-circuits the probes and runs the action against
+      // the inner RxList, which then heals or throws exactly as it would
+      // standalone.
+      final healing = RxList<int>(RxList<int>(List<int>.empty()));
+      healing.add(1);
+      expect(healing, [1]);
+
+      final frozen = RxList<int>(RxList<int>(List<int>.unmodifiable([1, 2])));
+      expect(() => frozen.add(3), throwsUnsupportedError);
+      expect(frozen, [1, 2]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('RxList.unmodifiable is genuinely unmodifiable', () {
+    test('every length-changing mutator throws', () {
+      for (final mutate in <void Function(RxList<int>)>[
+        (l) => l.add(3),
+        (l) => l.addAll([3]),
+        (l) => l.insert(0, 3),
+        (l) => l.insertAll(0, [3]),
+        (l) => l.remove(1),
+        (l) => l.removeAt(0),
+        (l) => l.removeLast(),
+        (l) => l.removeRange(0, 1),
+        (l) => l.removeWhere((e) => true),
+        (l) => l.retainWhere((e) => false),
+        (l) => l.replaceRange(0, 1, [9]),
+        (l) => l.clear(),
+        (l) => l.length = 0,
+        (l) => l + <int>[3],
+      ]) {
+        final list = RxList<int>.unmodifiable([1, 2]);
+        expect(() => mutate(list), throwsUnsupportedError);
+        expect(list, [1, 2]);
+      }
+    });
+
+    test('every element-writing mutator throws', () {
+      for (final mutate in <void Function(RxList<int>)>[
+        (l) => l[0] = 9,
+        (l) => l.first = 9,
+        (l) => l.last = 9,
+        (l) => l.setAll(0, [9]),
+        (l) => l.setRange(0, 1, [9]),
+        (l) => l.fillRange(0, 1, 9),
+        (l) => l.sort(),
+        (l) => l.shuffle(),
+      ]) {
+        final list = RxList<int>.unmodifiable([1, 2]);
+        expect(() => mutate(list), throwsUnsupportedError);
+        expect(list, [1, 2]);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('RxList errors still propagate', () {
+    test('insert past the end throws RangeError and changes nothing', () async {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final list = RxList<int>(backing);
+      var notifications = 0;
+      list.listen((_) => notifications++);
+
+      expect(() => list.insert(999, 4), throwsRangeError);
+      await Future.delayed(Duration.zero);
+
+      expect(list, [1, 2, 3]);
+      expect(identical(list.value, backing), isTrue);
+      expect(notifications, 0);
+    });
+
+    test('removeAt past the end throws RangeError on the heal path', () async {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final list = RxList<int>(backing);
+      var notifications = 0;
+      list.listen((_) => notifications++);
+
+      expect(() => list.removeAt(99), throwsRangeError);
+      await Future.delayed(Duration.zero);
+
+      expect(list, [1, 2, 3]);
+      expect(
+        identical(list.value, backing),
+        isTrue,
+        reason: 'a copy that failed mid-flight is never published',
+      );
+      expect(notifications, 0);
+    });
+
+    test('removeAt past the end on an unmodifiable backing throws '
+        'UnsupportedError, not RangeError', () async {
+      // The backing rejects the whole operation before it ever gets as far
+      // as validating the index, and that error is passed through untouched.
+      final list = RxList<int>(List<int>.unmodifiable([1, 2, 3]));
+      var notifications = 0;
+      list.listen((_) => notifications++);
+
+      expect(() => list.removeAt(99), throwsUnsupportedError);
+      await Future.delayed(Duration.zero);
+
+      expect(list, [1, 2, 3]);
+      expect(notifications, 0);
+    });
+
+    test('an exception from a sort comparator propagates', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [3, 1, 2]);
+      final list = RxList<int>(backing);
+
+      expect(
+        () => list.sort((a, b) => throw StateError('boom')),
+        throwsStateError,
+      );
+      expect(list, [3, 1, 2]);
+    });
+
+    test(
+      'an UnsupportedError from user code is NOT swallowed by the probes',
+      () {
+        // Only the capability probes may catch UnsupportedError; the real
+        // mutation must never be wrapped in a catch. Both paths are checked:
+        // `sort` runs in place, `removeWhere` runs through the heal path,
+        // which is where the probes actually fire.
+        final inPlace = RxList<int>(
+          List<int>.filled(3, 0)..setAll(0, [3, 1, 2]),
+        );
+        expect(
+          () => inPlace.sort((a, b) => throw UnsupportedError('from user')),
+          throwsUnsupportedError,
+        );
+        expect(inPlace, [3, 1, 2]);
+
+        final backing = List<int>.filled(3, 0)..setAll(0, [3, 1, 2]);
+        final healPath = RxList<int>(backing);
+        expect(
+          () =>
+              healPath.removeWhere((e) => throw UnsupportedError('from user')),
+          throwsUnsupportedError,
+        );
+        expect(healPath, [3, 1, 2]);
+        expect(identical(healPath.value, backing), isTrue);
+      },
+    );
+
+    test('a throwing predicate leaves the backing untouched', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final list = RxList<int>(backing);
+
+      expect(
+        () => list.removeWhere((e) => throw StateError('boom')),
+        throwsStateError,
+      );
+      expect(list, [1, 2, 3]);
+      expect(
+        identical(list.value, backing),
+        isTrue,
+        reason: 'a failed copy must not be published',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RxSet — mutable backings behave as always; unmodifiable ones throw. There
+  // is no fixed-length-but-writable Set in dart:core, so RxSet has no heal
+  // path at all.
+  // -------------------------------------------------------------------------
+  for (final backing in _mutableSetBackings.entries) {
+    group('RxSet over ${backing.key}', () {
+      for (final c in _setCases) {
+        if (backing.value(c.seed) == null) continue;
+        test(
+          '${c.name} works and notifies ${c.notifications} time(s)',
+          () async {
+            final set = RxSet<int>(backing.value(c.seed)!);
+            var notifications = 0;
+            set.listen((_) => notifications++);
+
+            c.apply(set);
+            await Future.delayed(Duration.zero);
+
+            expect(set, c.expected);
+            expect(notifications, c.notifications);
+          },
+        );
+      }
+    });
+  }
+
+  for (final backing in _frozenSetBackings.entries) {
+    group('RxSet over ${backing.key}', () {
+      for (final c in _setCases) {
+        if (backing.value(c.seed) == null) continue;
+        test('${c.name} throws UnsupportedError and changes nothing', () async {
+          final source = backing.value(c.seed)!;
+          final set = RxSet<int>(source);
+          var notifications = 0;
+          set.listen((_) => notifications++);
+
+          expect(() => c.apply(set), throwsUnsupportedError);
+          await Future.delayed(Duration.zero);
+
+          expect(set, unorderedEquals(c.seed));
+          expect(identical(set.value, source), isTrue);
+          expect(notifications, 0);
+        });
+      }
+    });
+  }
+
+  group('RxSet backing behaviour', () {
+    test('an unmodifiable backing is never swapped out', () {
+      final backing = Set<int>.unmodifiable({1, 2});
+      final set = RxSet<int>(backing);
+
+      expect(() => set.add(3), throwsUnsupportedError);
+
+      expect(backing, {1, 2});
+      expect(set, unorderedEquals(<int>[1, 2]));
+      expect(identical(set.value, backing), isTrue);
+    });
+
+    test('a mutable backing is still mutated in place (aliasing kept)', () {
+      final backing = <int>{1};
+      final set = RxSet<int>(backing);
+
+      set.add(2);
+
+      expect(backing, {1, 2});
+      expect(identical(set.value, backing), isTrue);
+    });
+
+    test('RxSet.unmodifiable is genuinely unmodifiable', () {
+      for (final mutate in <void Function(RxSet<int>)>[
+        (s) => s.add(3),
+        (s) => s.addAll({3}),
+        (s) => s.remove(1),
+        (s) => s.removeAll([1]),
+        (s) => s.retainAll([1]),
+        (s) => s.removeWhere((e) => true),
+        (s) => s.retainWhere((e) => false),
+        (s) => s.clear(),
+        (s) => s.update((v) => (v! as Set<int>).add(3)),
+        (s) => s + <int>{3},
+      ]) {
+        final set = RxSet<int>.unmodifiable([1, 2]);
+        expect(() => mutate(set), throwsUnsupportedError);
+        expect(set, unorderedEquals(<int>[1, 2]));
+      }
+    });
+
+    test('update hands the callback the real backing set', () {
+      // Not a defensive copy: if the caller declared the set unmodifiable, a
+      // mutation inside the callback must be rejected like any other.
+      final set = RxSet<int>(Set<int>.unmodifiable({1}));
+
+      expect(
+        () => set.update((v) => (v! as Set<int>).add(2)),
+        throwsUnsupportedError,
+      );
+      expect(set, unorderedEquals(<int>[1]));
+    });
+
+    test('a throwing callback leaves a mutable backing untouched', () {
+      final backing = <int>{1, 2};
+      final set = RxSet<int>(backing);
+
+      expect(
+        () => set.removeWhere((e) => throw StateError('boom')),
+        throwsStateError,
+      );
+      expect(set, unorderedEquals(<int>[1, 2]));
+      expect(identical(set.value, backing), isTrue);
+    });
+
+    test(
+      'a nested RxSet backing is notified once, by the real mutation',
+      () async {
+        final inner = RxSet<int>(<int>{1});
+        final outer = RxSet<int>(inner);
+        var innerNotifications = 0;
+        var outerNotifications = 0;
+        inner.listen((_) => innerNotifications++);
+        outer.listen((_) => outerNotifications++);
+
+        outer.add(2);
+        await Future.delayed(Duration.zero);
+
+        expect(outer, unorderedEquals(<int>[1, 2]));
+        expect(outerNotifications, 1);
+        expect(innerNotifications, 1);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // RxMap
+  // -------------------------------------------------------------------------
+  for (final backing in _mutableMapBackings.entries) {
+    group('RxMap over ${backing.key}', () {
+      for (final c in _mapCases) {
+        if (backing.value(c.seed) == null) continue;
+        test(
+          '${c.name} works and notifies ${c.notifications} time(s)',
+          () async {
+            final map = RxMap<String, int>(backing.value(c.seed)!);
+            var notifications = 0;
+            map.listen((_) => notifications++);
+
+            c.apply(map);
+            await Future.delayed(Duration.zero);
+
+            expect(map, c.expected);
+            expect(notifications, c.notifications);
+          },
+        );
+      }
+    });
+  }
+
+  for (final backing in _frozenMapBackings.entries) {
+    group('RxMap over ${backing.key}', () {
+      for (final c in _mapCases) {
+        if (backing.value(c.seed) == null) continue;
+        test('${c.name} throws UnsupportedError and changes nothing', () async {
+          final source = backing.value(c.seed)!;
+          final map = RxMap<String, int>(source);
+          var notifications = 0;
+          map.listen((_) => notifications++);
+
+          expect(() => c.apply(map), throwsUnsupportedError);
+          await Future.delayed(Duration.zero);
+
+          expect(map, equals(c.seed));
+          expect(identical(map.value, source), isTrue);
+          expect(notifications, 0);
+        });
+      }
+    });
+  }
+
+  group('RxMap backing behaviour', () {
+    test('an unmodifiable backing is never swapped out', () {
+      final backing = Map<String, int>.unmodifiable({'a': 1});
+      final map = RxMap<String, int>(backing);
+
+      expect(() => map['b'] = 2, throwsUnsupportedError);
+
+      expect(backing, {'a': 1});
+      expect(map, {'a': 1});
+      expect(identical(map.value, backing), isTrue);
+    });
+
+    test('a mutable backing is still mutated in place (aliasing kept)', () {
+      final backing = <String, int>{'a': 1};
+      final map = RxMap<String, int>(backing);
+
+      map['b'] = 2;
+
+      expect(backing, {'a': 1, 'b': 2});
+      expect(identical(map.value, backing), isTrue);
+    });
+
+    test('RxMap.unmodifiable is genuinely unmodifiable', () {
+      for (final mutate in <void Function(RxMap<String, int>)>[
+        (m) => m['b'] = 2,
+        (m) => m.addAll({'b': 2}),
+        (m) => m.addEntries([const MapEntry('b', 2)]),
+        (m) => m.putIfAbsent('b', () => 2),
+        (m) => m.update('a', (v) => v + 1),
+        (m) => m.updateAll((k, v) => v),
+        (m) => m.remove('a'),
+        (m) => m.removeWhere((k, v) => true),
+        (m) => m.clear(),
+      ]) {
+        final map = RxMap<String, int>.unmodifiable({'a': 1});
+        expect(() => mutate(map), throwsUnsupportedError);
+        expect(map, {'a': 1});
+      }
+    });
+
+    test('update on a missing key of an unmodifiable backing throws '
+        'UnsupportedError, not ArgumentError', () async {
+      // The backing rejects the write before `Map.update` gets far enough to
+      // complain about the missing key.
+      final backing = Map<String, int>.unmodifiable({'a': 1});
+      final map = RxMap<String, int>(backing);
+      var notifications = 0;
+      map.listen((_) => notifications++);
+
+      expect(() => map.update('z', (v) => v), throwsUnsupportedError);
+      await Future.delayed(Duration.zero);
+
+      expect(map, {'a': 1});
+      expect(identical(map.value, backing), isTrue);
+      expect(notifications, 0);
+    });
+
+    test('update on a missing key of a mutable backing still throws', () async {
+      final backing = <String, int>{'a': 1};
+      final map = RxMap<String, int>(backing);
+      var notifications = 0;
+      map.listen((_) => notifications++);
+
+      expect(() => map.update('z', (v) => v), throwsArgumentError);
+      await Future.delayed(Duration.zero);
+
+      expect(map, {'a': 1});
+      expect(identical(map.value, backing), isTrue);
+      expect(notifications, 0);
+    });
+
+    test('a throwing callback leaves a mutable backing untouched', () {
+      final backing = <String, int>{'a': 1};
+      final map = RxMap<String, int>(backing);
+
+      expect(
+        () => map.removeWhere((k, v) => throw StateError('boom')),
+        throwsStateError,
+      );
+      expect(map, {'a': 1});
+      expect(identical(map.value, backing), isTrue);
+    });
+
+    test(
+      'a nested RxMap backing is notified once, by the real mutation',
+      () async {
+        final inner = RxMap<String, int>(<String, int>{'a': 1});
+        final outer = RxMap<String, int>(inner);
+        var innerNotifications = 0;
+        var outerNotifications = 0;
+        inner.listen((_) => innerNotifications++);
+        outer.listen((_) => outerNotifications++);
+
+        outer['b'] = 2;
+        await Future.delayed(Duration.zero);
+
+        expect(outer, {'a': 1, 'b': 2});
+        expect(outerNotifications, 1);
+        expect(innerNotifications, 1);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // The intended seam.
+  // -------------------------------------------------------------------------
+  group('the intended seam: assign/assignAll heal, add/insert throw', () {
+    // This asymmetry is a DECISION, not an oversight, and must not be
+    // "fixed" in either direction:
+    //
+    //   * `assignAll` REPLACES the contents wholesale. Nothing of the old
+    //     collection survives, so which object happened to be holding those
+    //     contents is an implementation detail with nothing left to protect —
+    //     it publishes a fresh mutable collection and succeeds.
+    //   * `add`/`insert`/`[]=` MUTATE a collection the caller explicitly
+    //     declared unmodifiable. Letting them through would silently delete a
+    //     guard, with no compile error to warn anyone.
+    //
+    // fixed_length_backing_assign_test.dart pins the assign/assignAll half in
+    // detail; these tests pin the two halves side by side so the seam itself
+    // is visible.
+
+    test('RxList: assignAll succeeds where add throws', () async {
+      final list = RxList<int>(List<int>.unmodifiable([1, 2]));
+      var notifications = 0;
+      list.listen((_) => notifications++);
+
+      expect(() => list.add(3), throwsUnsupportedError);
+      expect(list, [1, 2]);
+
+      list.assignAll([7, 8]);
+      expect(list, [7, 8]);
+
+      // ...and the RxList is plainly mutable afterwards: the unmodifiable
+      // backing is gone, replaced by the fresh growable list assignAll built.
+      list.add(9);
+      expect(list, [7, 8, 9]);
+
+      await Future.delayed(Duration.zero);
+      expect(notifications, 2, reason: 'assignAll, then add. Never the throw.');
+    });
+
+    test('RxList: assign succeeds where insert throws', () {
+      final list = RxList<int>(const <int>[1, 2]);
+
+      expect(() => list.insert(0, 0), throwsUnsupportedError);
+      expect(list, [1, 2]);
+
+      list.assign(7);
+      expect(list, [7]);
+    });
+
+    test('RxSet: assignAll succeeds where add throws', () async {
+      final set = RxSet<int>(Set<int>.unmodifiable({1, 2}));
+      var notifications = 0;
+      set.listen((_) => notifications++);
+
+      expect(() => set.add(3), throwsUnsupportedError);
+      expect(set, unorderedEquals(<int>[1, 2]));
+
+      set.assignAll([7, 8]);
+      expect(set, unorderedEquals(<int>[7, 8]));
+
+      set.add(9);
+      expect(set, unorderedEquals(<int>[7, 8, 9]));
+
+      await Future.delayed(Duration.zero);
+      expect(notifications, 2);
+    });
+
+    test('RxSet: the assignAll copy keeps the runtime element type', () {
+      // toSet() reifies the BACKING's element type, not the RxSet's type
+      // argument, so the fresh set is a Set<int> and keeps rejecting
+      // incompatible elements exactly as the backing did.
+      final RxSet<num> set = RxSet<num>(Set<int>.unmodifiable({1, 2}));
+
+      set.assignAll(<int>[3, 4]);
+      expect(set, unorderedEquals(<num>[3, 4]));
+      expect(() => set.add(0.5), throwsA(isA<TypeError>()));
+
+      // Strict enough that even a compatible-looking `Iterable<num>` is
+      // rejected, because `Set<int>.addAll` will not accept one.
+      expect(
+        () => set.assignAll(<num>[5, 6]),
+        throwsA(isA<TypeError>()),
+        reason: 'the copy is a Set<int>, so addAll wants an Iterable<int>',
+      );
+    });
+
+    test('RxMap: assignAll succeeds where []= throws', () async {
+      final map = RxMap<String, int>(Map<String, int>.unmodifiable({'a': 1}));
+      var notifications = 0;
+      map.listen((_) => notifications++);
+
+      expect(() => map['b'] = 2, throwsUnsupportedError);
+      expect(map, {'a': 1});
+
+      map.assignAll(<String, int>{'z': 9});
+      expect(map, {'z': 9});
+
+      map['y'] = 8;
+      expect(map, {'z': 9, 'y': 8});
+
+      await Future.delayed(Duration.zero);
+      expect(notifications, 2);
+    });
+
+    test('RxMap: the assign copy is parameterised by K and V', () {
+      // Documented trade-off: Map has no runtime-type-preserving copy the way
+      // List.toList()/Set.toSet() do, so assign publishes a plain Map<K, V>.
+      final RxMap<Object, Object> map = RxMap<Object, Object>(
+        Map<String, int>.unmodifiable({'a': 1}),
+      );
+
+      map.assign('b', 2);
+      map[1] = 'accepted after the swap';
+
+      expect(map, {'b': 2, 1: 'accepted after the swap'});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('worker and Obx integration', () {
+    test(
+      'ever() fires exactly once per mutation of a fixed-backing RxList',
+      () async {
+        final list = RxList<int>(List<int>.empty());
+        final seen = <List<int>>[];
+        final worker = ever<List<int>>(
+          list,
+          (value) => seen.add(List<int>.of(value)),
+        );
+
+        list.add(1);
+        await Future.delayed(Duration.zero);
+        list.insert(0, 0);
+        await Future.delayed(Duration.zero);
+        list.clear();
+        await Future.delayed(Duration.zero);
+
+        expect(seen, [
+          [1],
+          [0, 1],
+          <int>[],
+        ]);
+        worker.dispose();
+      },
+    );
+
+    test('ever() never fires for a rejected mutation', () async {
+      final map = RxMap<String, int>(Map<String, int>.unmodifiable({'a': 1}));
+      var calls = 0;
+      final worker = ever<Map<String, int>>(map, (_) => calls++);
+
+      expect(() => map['b'] = 2, throwsUnsupportedError);
+      await Future.delayed(Duration.zero);
+      expect(calls, 0);
+
+      // The surviving seam still reaches the worker.
+      map.assignAll(<String, int>{'z': 9});
+      await Future.delayed(Duration.zero);
+
+      expect(calls, 1);
+      expect(map, {'z': 9});
+      worker.dispose();
+    });
+
+    testWidgets('Obx rebuilds once per mutation of a fixed-backing RxList', (
+      tester,
+    ) async {
+      final list = RxList<int>(List<int>.empty());
+      var builds = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Obx(() {
+            builds++;
+            return Text('items: ${list.length}');
+          }),
+        ),
+      );
+      expect(builds, 1);
+      expect(find.text('items: 0'), findsOneWidget);
+
+      // Obx schedules its rebuild in a microtask, so drain those (idle())
+      // before asking for a frame.
+      list.insert(0, 1);
+      await tester.idle();
+      await tester.pump();
+      expect(builds, 2);
+      expect(find.text('items: 1'), findsOneWidget);
+
+      list.addAll([2, 3]);
+      await tester.idle();
+      await tester.pump();
+      expect(builds, 3);
+      expect(find.text('items: 3'), findsOneWidget);
+
+      list.clear();
+      await tester.idle();
+      await tester.pump();
+      expect(builds, 4);
+      expect(find.text('items: 0'), findsOneWidget);
+    });
+  });
+}

--- a/test/rx/rx_collection_backing_equivalence_test.dart
+++ b/test/rx/rx_collection_backing_equivalence_test.dart
@@ -1,0 +1,1426 @@
+// Property / differential tests for the backing collections of RxList, RxSet
+// and RxMap under the *narrow* healing contract.
+//
+// fixed_length_backing_assign_test.dart pins down individual crashes. These
+// tests pin down the two *properties* the hardening is supposed to deliver,
+// which are duals of each other:
+//
+//  1. EQUIVALENCE. A backing that carries no immutability intent — a
+//     fixed-length list such as `List.empty()`, `List.filled()` or a
+//     `Uint8List` — must be observationally INDISTINGUISHABLE from a plain
+//     growable list. Every operation is run against a growable control and
+//     against one subject per awkward backing shape, and the contents, length,
+//     iteration order, return value, thrown error type and listener
+//     notification count are diffed.
+//
+//  2. REJECTION. A backing that *is* an explicit opt-in to immutability —
+//     `List.unmodifiable`, `const [...]`, `UnmodifiableListView`,
+//     `Set.unmodifiable`, `Map.unmodifiable` — must NOT be equivalent. Where
+//     the growable control succeeds, the unmodifiable subject throws
+//     `UnsupportedError`, notifies nobody, keeps its contents, and — the
+//     important anti-regression — keeps its *identity*: a failed capability
+//     probe must have no side effect, so the RxList must still be holding the
+//     very same backing object afterwards and must still reject the next
+//     mutation. Unmodifiable is forever.
+//
+// `assign` / `assignAll` are the single documented exception to (2): they
+// replace the contents wholesale by publishing a fresh mutable collection, so
+// they succeed on every backing and are diffed against the control like a
+// fixed-length subject. Each operation below declares which side of that line
+// it falls on via [_Unmod].
+//
+// RxSet and RxMap have no healing at all — `dart:core` has no
+// fixed-length-but-writable Set or Map, so "unmodifiable" is their only
+// failure mode and it is always honoured. Their equivalence sections
+// therefore only carry mutable and nested-Rx subjects.
+//
+// Notifications are counted through `addListener` — the synchronous fan-out
+// that both `refresh()` and `value =` end in — rather than through the
+// broadcast stream, so the counts are exact and need no event-loop turn. Two
+// tests at the bottom cross-check that the stream sees the same thing.
+import 'dart:collection';
+import 'dart:math';
+
+// `Uint8List` comes from foundation's re-export of `dart:typed_data`;
+// importing it directly here would be flagged as an unnecessary import.
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getxify/get_rx/get_rx.dart';
+
+/// What an operation is expected to do to a collection whose backing is an
+/// explicit opt-in to immutability.
+enum _Unmod {
+  /// The backing's own [UnsupportedError] comes out, nothing changes and
+  /// nobody is notified. This is the case for every real mutator.
+  throws,
+
+  /// The operation succeeds and stays equivalent to the growable control.
+  /// Only `assign`/`assignAll` (which replace the contents wholesale) and
+  /// operations that never actually attempt a mutation qualify.
+  succeeds,
+}
+
+/// A named operation applied to a collection of type [T].
+class _Op<T> {
+  const _Op(this.name, this.run, {this.unmod = _Unmod.throws});
+
+  /// An operation whose return value is not part of its contract.
+  factory _Op.action(
+    String name,
+    void Function(T target) body, {
+    _Unmod unmod = _Unmod.throws,
+  }) {
+    return _Op<T>(name, (target) {
+      body(target);
+      return null;
+    }, unmod: unmod);
+  }
+
+  final String name;
+
+  /// Returns whatever the member under test returns, so return values are
+  /// diffed too; `null` stands in for a `void` member.
+  final Object? Function(T target) run;
+
+  /// Behaviour over an unmodifiable backing. See [_Unmod].
+  final _Unmod unmod;
+}
+
+typedef _ListOp = _Op<RxList<int>>;
+typedef _SetOp = _Op<RxSet<int>>;
+typedef _MapOp = _Op<RxMap<String, int>>;
+
+const _listSeed = <int>[1, 2, 3];
+const _setSeed = <int>{1, 2, 3};
+const _mapSeed = <String, int>{'a': 1, 'b': 2};
+
+List<int> _growableSeed() => List<int>.of(_listSeed);
+Set<int> _mutableSeed() => Set<int>.of(_setSeed);
+Map<String, int> _mutableMapSeed() => Map<String, int>.of(_mapSeed);
+
+/// Backings that all hold `[1, 2, 3]` and must all behave exactly like a
+/// plain growable list: either they already are mutable, or they are
+/// fixed-length and therefore heal on the first length change.
+///
+/// The growable entry is the control run as a subject, so the harness
+/// self-checks.
+final _equivalentListBackings = <String, List<int> Function()>{
+  'growable (self-check)': _growableSeed,
+  'fixed-length (List.of growable: false)': () =>
+      List<int>.of(_listSeed, growable: false),
+  'fixed-length (List.filled)': () =>
+      List<int>.filled(3, 0, growable: false)..setAll(0, _listSeed),
+  // The canonical "fixed-length but very much writable" buffer, and a
+  // different implementation class from `_List`.
+  'fixed-length (Uint8List)': () => Uint8List.fromList(_listSeed),
+  // Reachable through `someRxList.obs`, and the one shape both capability
+  // probes short-circuit instead of probing.
+  'nested RxList': () => RxList<int>(_growableSeed()),
+};
+
+/// Backings that declared themselves immutable and must never be healed.
+final _unmodifiableListBackings = <String, List<int> Function()>{
+  'List.unmodifiable': () => List<int>.unmodifiable(_listSeed),
+  'const literal': () => _listSeed,
+  // A different implementation class again: a live *view* over a growable
+  // list, which the probes must classify by behaviour rather than by type.
+  'UnmodifiableListView': () => UnmodifiableListView<int>(_growableSeed()),
+};
+
+/// The empty counterparts, i.e. the exact shape of the production report:
+/// `RxList<T> x = List<T>.empty().obs;`.
+final _equivalentEmptyListBackings = <String, List<int> Function()>{
+  'growable (self-check)': () => <int>[],
+  'fixed-length (List.empty)': () => List<int>.empty(),
+  'fixed-length (Uint8List)': () => Uint8List(0),
+  'nested RxList': () => RxList<int>(<int>[]),
+};
+
+final _unmodifiableEmptyListBackings = <String, List<int> Function()>{
+  'List.unmodifiable': () => List<int>.unmodifiable(const []),
+  'const literal': () => const <int>[],
+  'UnmodifiableListView': () => UnmodifiableListView<int>(<int>[]),
+};
+
+/// RxSet never heals, so the only equivalent subjects are ones that were
+/// mutable to begin with.
+final _equivalentSetBackings = <String, Set<int> Function()>{
+  'mutable (self-check)': _mutableSeed,
+  'nested RxSet': () => RxSet<int>(_mutableSeed()),
+};
+
+final _unmodifiableSetBackings = <String, Set<int> Function()>{
+  'Set.unmodifiable': () => Set<int>.unmodifiable(_setSeed),
+  'const literal': () => _setSeed,
+  'UnmodifiableSetView': () => UnmodifiableSetView<int>(_mutableSeed()),
+};
+
+final _equivalentMapBackings = <String, Map<String, int> Function()>{
+  'mutable (self-check)': _mutableMapSeed,
+  'nested RxMap': () => RxMap<String, int>(_mutableMapSeed()),
+};
+
+final _unmodifiableMapBackings = <String, Map<String, int> Function()>{
+  'Map.unmodifiable': () => Map<String, int>.unmodifiable(_mapSeed),
+  'const literal': () => _mapSeed,
+  'UnmodifiableMapView': () =>
+      UnmodifiableMapView<String, int>(_mutableMapSeed()),
+};
+
+/// Everything observable about a collection after one operation ran on it.
+class _Result {
+  const _Result({
+    required this.contents,
+    required this.iterated,
+    required this.length,
+    required this.result,
+    required this.notifications,
+    required this.error,
+  });
+
+  final List<Object?> contents;
+  final List<Object?> iterated;
+  final int length;
+  final Object? result;
+  final int notifications;
+  final Object? error;
+}
+
+/// Attaches a synchronous listener and returns a getter for its call count.
+int Function() _watch(Listenable rx) {
+  var count = 0;
+  rx.addListener(() => count++);
+  return () => count;
+}
+
+_Result _runList(List<int> backing, _ListOp op) {
+  final rx = RxList<int>(backing);
+  final notifications = _watch(rx);
+  Object? result;
+  Object? error;
+  try {
+    result = op.run(rx);
+  } catch (e) {
+    error = e;
+  }
+  return _Result(
+    contents: rx.toList(),
+    iterated: [for (final element in rx) element],
+    length: rx.length,
+    result: result,
+    notifications: notifications(),
+    error: error,
+  );
+}
+
+_Result _runSet(Set<int> backing, _SetOp op) {
+  final rx = RxSet<int>(backing);
+  final notifications = _watch(rx);
+  Object? result;
+  Object? error;
+  try {
+    result = op.run(rx);
+  } catch (e) {
+    error = e;
+  }
+  return _Result(
+    contents: rx.toList(),
+    iterated: [for (final element in rx) element],
+    length: rx.length,
+    result: result,
+    notifications: notifications(),
+    error: error,
+  );
+}
+
+_Result _runMap(Map<String, int> backing, _MapOp op) {
+  final rx = RxMap<String, int>(backing);
+  final notifications = _watch(rx);
+  Object? result;
+  Object? error;
+  try {
+    result = op.run(rx);
+  } catch (e) {
+    error = e;
+  }
+  return _Result(
+    contents: [for (final key in rx.keys) '$key=${rx[key]}'],
+    iterated: rx.keys.toList(),
+    length: rx.length,
+    result: result,
+    notifications: notifications(),
+    error: error,
+  );
+}
+
+/// Diffs a subject against the control. [maxNotifications] is `null` for
+/// multi-operation sequences, where more than one notification is expected.
+void _expectSame(
+  String label,
+  _Result subject,
+  _Result control, {
+  int? maxNotifications = 1,
+}) {
+  expect(subject.contents, control.contents, reason: '$label: contents');
+  expect(subject.iterated, control.iterated, reason: '$label: iteration order');
+  expect(subject.length, control.length, reason: '$label: length');
+  expect(subject.result, control.result, reason: '$label: return value');
+  // Only the runtime type is compared: the messages embed indices and lengths
+  // that are equal here anyway, but comparing them would make the tests
+  // hostage to dart:core wording.
+  expect(
+    subject.error?.runtimeType,
+    control.error?.runtimeType,
+    reason:
+        '$label: thrown error (subject ${subject.error}, '
+        'control ${control.error})',
+  );
+  expect(
+    subject.notifications,
+    control.notifications,
+    reason: '$label: notification count',
+  );
+  if (maxNotifications != null) {
+    expect(
+      subject.notifications,
+      lessThanOrEqualTo(maxNotifications),
+      reason: '$label: one call must notify at most once',
+    );
+  }
+}
+
+/// The dual of [_expectSame] for a list: the operation must be *rejected* by
+/// the backing, leaving no trace at all.
+void _expectListRejects(
+  String label,
+  List<int> backing,
+  _ListOp op,
+  List<int> seed,
+) {
+  final before = backing.toList();
+  final rx = RxList<int>(backing);
+  final notifications = _watch(rx);
+
+  expect(
+    () => op.run(rx),
+    throwsUnsupportedError,
+    reason: "$label: an unmodifiable backing must surface its own error",
+  );
+  expect(rx, seed, reason: '$label: contents must be unchanged');
+  expect(rx.length, seed.length, reason: '$label: length must be unchanged');
+  expect(notifications(), 0, reason: '$label: nobody may be notified');
+  expect(
+    identical(rx.value, backing),
+    isTrue,
+    reason:
+        '$label: the backing must not have been swapped — a failed '
+        'capability probe must have no side effect',
+  );
+  expect(backing, before, reason: '$label: the backing itself is untouched');
+  expect(
+    () => rx.add(999),
+    throwsUnsupportedError,
+    reason: '$label: unmodifiable is forever',
+  );
+  expect(identical(rx.value, backing), isTrue, reason: '$label: still aliased');
+}
+
+void _expectSetRejects(String label, Set<int> backing, _SetOp op) {
+  final before = backing.toSet();
+  final rx = RxSet<int>(backing);
+  final notifications = _watch(rx);
+
+  expect(() => op.run(rx), throwsUnsupportedError, reason: label);
+  expect(rx, _setSeed, reason: '$label: contents must be unchanged');
+  expect(notifications(), 0, reason: '$label: nobody may be notified');
+  expect(
+    identical(rx.value, backing),
+    isTrue,
+    reason: '$label: the backing must not have been swapped',
+  );
+  expect(backing, before, reason: '$label: the backing itself is untouched');
+  expect(
+    () => rx.add(999),
+    throwsUnsupportedError,
+    reason: '$label: unmodifiable is forever',
+  );
+}
+
+void _expectMapRejects(String label, Map<String, int> backing, _MapOp op) {
+  final before = Map<String, int>.of(backing);
+  final rx = RxMap<String, int>(backing);
+  final notifications = _watch(rx);
+
+  expect(() => op.run(rx), throwsUnsupportedError, reason: label);
+  expect(rx, _mapSeed, reason: '$label: contents must be unchanged');
+  expect(notifications(), 0, reason: '$label: nobody may be notified');
+  expect(
+    identical(rx.value, backing),
+    isTrue,
+    reason: '$label: the backing must not have been swapped',
+  );
+  expect(backing, before, reason: '$label: the backing itself is untouched');
+  expect(
+    () => rx['zz'] = 1,
+    throwsUnsupportedError,
+    reason: '$label: unmodifiable is forever',
+  );
+}
+
+/// Single-call mutations of an `RxList<int>` seeded with `[1, 2, 3]`.
+final _listOps = <_ListOp>[
+  // --- length-changing members -------------------------------------------
+  _ListOp.action('add', (l) => l.add(4)),
+  _ListOp.action('addAll', (l) => l.addAll([4, 5])),
+  _ListOp.action('addAll (empty)', (l) => l.addAll(const <int>[])),
+  // The exact production crash: insert into a fixed-length backing.
+  _ListOp.action('insert at 0', (l) => l.insert(0, 0)),
+  _ListOp.action('insert at end', (l) => l.insert(3, 9)),
+  _ListOp.action('insertAll', (l) => l.insertAll(1, [7, 8])),
+  _ListOp('remove (present)', (l) => l.remove(2)),
+  _ListOp('remove (absent)', (l) => l.remove(99)),
+  _ListOp('removeAt', (l) => l.removeAt(1)),
+  _ListOp('removeLast', (l) => l.removeLast()),
+  _ListOp.action('removeRange', (l) => l.removeRange(0, 2)),
+  _ListOp.action('removeWhere', (l) => l.removeWhere((e) => e.isEven)),
+  _ListOp.action('removeWhere (no match)', (l) => l.removeWhere((e) => e > 9)),
+  _ListOp.action('retainWhere', (l) => l.retainWhere((e) => e > 1)),
+  // The second latent crash in the production report.
+  _ListOp.action('clear', (l) => l.clear()),
+  _ListOp('length = 0', (l) => l.length = 0),
+  _ListOp('length = 1', (l) => l.length = 1),
+  _ListOp.action('replaceRange (shorter)', (l) => l.replaceRange(0, 2, [9])),
+  // FixedLengthListMixin.replaceRange throws even when the length is kept.
+  _ListOp.action('replaceRange (same length)', (l) {
+    l.replaceRange(0, 1, [9]);
+  }),
+  _ListOp.action('replaceRange (longer)', (l) {
+    l.replaceRange(0, 1, [8, 9]);
+  }),
+  _ListOp('operator + returns this', (l) => identical(l + <int>[4, 5], l)),
+  // --- element-writing members -------------------------------------------
+  // These need no healing: a fixed-length list accepts them in place and an
+  // unmodifiable one rejects them on its own.
+  _ListOp.action('operator []=', (l) => l[0] = 9),
+  _ListOp.action('first =', (l) => l.first = 9),
+  _ListOp.action('last =', (l) => l.last = 9),
+  _ListOp.action('sort (default)', (l) => l.sort()),
+  _ListOp.action('sort (descending)', (l) => l.sort((a, b) => b.compareTo(a))),
+  // The same seed makes shuffle deterministic; every list implementation
+  // shares ListBase.shuffle, so the control and the subjects must agree.
+  _ListOp.action('shuffle (seeded)', (l) => l.shuffle(Random(42))),
+  _ListOp.action('setAll', (l) => l.setAll(1, [7, 8])),
+  _ListOp.action('setRange', (l) => l.setRange(0, 2, [7, 8])),
+  _ListOp.action('setRange (skipCount)', (l) {
+    l.setRange(0, 2, [0, 7, 8], 1);
+  }),
+  _ListOp.action('fillRange', (l) => l.fillRange(0, 2, 9)),
+  // --- members that only delegate ----------------------------------------
+  _ListOp.action('addNonNull', (l) => l.addNonNull(4)),
+  _ListOp.action('addIf (true)', (l) => l.addIf(true, 4)),
+  // Never touches the backing at all, so it is fine everywhere.
+  _ListOp.action(
+    'addIf (false)',
+    (l) => l.addIf(false, 4),
+    unmod: _Unmod.succeeds,
+  ),
+  _ListOp.action('addAllIf (true)', (l) => l.addAllIf(true, [4, 5])),
+  _ListOp.action('cast view add', (l) => l.cast<num>().add(4)),
+  // --- the documented exception ------------------------------------------
+  // assign/assignAll replace the contents wholesale, so they publish a fresh
+  // growable list instead of mutating the current one and therefore work over
+  // an unmodifiable backing too.
+  _ListOp.action('assign', (l) => l.assign(9), unmod: _Unmod.succeeds),
+  _ListOp.action(
+    'assignAll',
+    (l) => l.assignAll([7, 8, 9]),
+    unmod: _Unmod.succeeds,
+  ),
+  _ListOp.action(
+    'assignAll (empty)',
+    (l) => l.assignAll(const <int>[]),
+    unmod: _Unmod.succeeds,
+  ),
+  // --- calls that must fail, and must fail identically -------------------
+  // Growing a List<int> writes nulls, so this throws a TypeError on the
+  // growable control and on the fixed-length subjects (inside the copy). An
+  // unmodifiable backing refuses before it ever gets that far.
+  _ListOp('length = 5 (grow non-nullable)', (l) => l.length = 5),
+  _ListOp('removeAt (out of range)', (l) => l.removeAt(99)),
+  _ListOp.action('insert (out of range)', (l) => l.insert(99, 0)),
+  _ListOp.action('removeRange (past end)', (l) => l.removeRange(0, 99)),
+  _ListOp.action('setRange (past end)', (l) => l.setRange(0, 9, [1, 2])),
+  _ListOp.action('setAll (past end)', (l) => l.setAll(2, [7, 8])),
+];
+
+/// Operations valid on an empty list, for the `List.empty()` backings.
+final _emptyListOps = <_ListOp>[
+  _ListOp.action('add', (l) => l.add(1)),
+  _ListOp.action('insert at 0', (l) => l.insert(0, 1)),
+  _ListOp.action('addAll', (l) => l.addAll([1, 2])),
+  _ListOp.action('clear', (l) => l.clear()),
+  _ListOp('length = 0', (l) => l.length = 0),
+  _ListOp('remove (absent)', (l) => l.remove(1)),
+  _ListOp.action('removeWhere', (l) => l.removeWhere((e) => true)),
+  // Vacuous, but the unmodifiable mixins throw for an empty range too.
+  _ListOp.action('sort', (l) => l.sort()),
+  // `shuffle` is the exception: with fewer than two elements there is nothing
+  // to swap, so `RxList.shuffle` returns without ever asking the backing to
+  // write — exactly as the inherited `ListMixin.shuffle` always did. It stays
+  // equivalent to the growable control instead of throwing.
+  _ListOp.action(
+    'shuffle (seeded)',
+    (l) => l.shuffle(Random(7)),
+    unmod: _Unmod.succeeds,
+  ),
+  _ListOp.action('setRange (empty range)', (l) => l.setRange(0, 0, const [])),
+  _ListOp.action('fillRange (empty range)', (l) => l.fillRange(0, 0, 1)),
+  _ListOp.action(
+    'assignAll',
+    (l) => l.assignAll([1, 2]),
+    unmod: _Unmod.succeeds,
+  ),
+  _ListOp.action('assign', (l) => l.assign(1), unmod: _Unmod.succeeds),
+  _ListOp('removeLast (throws)', (l) => l.removeLast()),
+  _ListOp('operator + returns this', (l) => identical(l + <int>[1], l)),
+];
+
+/// Multi-operation sequences: a backing swapped mid-sequence must not change
+/// what the rest of the sequence does.
+final _listSequences = <_ListOp>[
+  _ListOp.action('clear, insert, add', (l) {
+    l.clear();
+    l.insert(0, 7);
+    l.add(8);
+  }),
+  _ListOp.action('insert at 0 three times', (l) {
+    for (var i = 0; i < 3; i++) {
+      l.insert(0, i);
+    }
+  }),
+  _ListOp.action('sort, removeWhere, addAll', (l) {
+    l.sort((a, b) => b.compareTo(a));
+    l.removeWhere((e) => e.isOdd);
+    l.addAll([10, 11]);
+  }),
+  // The one sequence that survives an unmodifiable backing: the leading
+  // assignAll replaces it with a fresh growable list, after which the rest of
+  // the sequence is ordinary.
+  _ListOp.action('assignAll, add, removeAt', (l) {
+    l.assignAll([5, 6, 7]);
+    l.add(8);
+    l.removeAt(0);
+  }, unmod: _Unmod.succeeds),
+  _ListOp.action('length = 0, addAll, sort', (l) {
+    l.length = 0;
+    l.addAll([3, 1, 2]);
+    l.sort();
+  }),
+  _ListOp.action('setAll, remove, insertAll', (l) {
+    l.setAll(0, [9, 8, 7]);
+    l.remove(8);
+    l.insertAll(0, [0, 1]);
+  }),
+  _ListOp.action('element write then length change', (l) {
+    // An element write leaves a fixed-length backing in place; the following
+    // length change still has to work.
+    l[0] = 42;
+    l.add(43);
+    l.removeLast();
+    l.shuffle(Random(3));
+  }),
+  _ListOp.action('failed op then successful op', (l) {
+    try {
+      l.removeAt(99);
+    } on RangeError {
+      // The failure must not corrupt or detach anything. On an unmodifiable
+      // backing the error is an UnsupportedError instead, so it escapes this
+      // catch — which is exactly the rejection the dual test asserts.
+    }
+    l.add(4);
+  }),
+];
+
+final _setOps = <_SetOp>[
+  _SetOp('add (new)', (s) => s.add(4)),
+  _SetOp('add (duplicate)', (s) => s.add(1)),
+  _SetOp.action('addAll', (s) => s.addAll({4, 5})),
+  _SetOp.action('addAll (empty)', (s) => s.addAll(const <int>{})),
+  _SetOp('remove (present)', (s) => s.remove(2)),
+  _SetOp('remove (absent)', (s) => s.remove(99)),
+  _SetOp.action('removeAll', (s) => s.removeAll([1, 2])),
+  _SetOp.action('removeAll (nothing)', (s) => s.removeAll([99])),
+  _SetOp.action('retainAll', (s) => s.retainAll([2])),
+  _SetOp.action('retainWhere', (s) => s.retainWhere((e) => e > 1)),
+  _SetOp.action('removeWhere', (s) => s.removeWhere((e) => e.isEven)),
+  _SetOp.action('clear', (s) => s.clear()),
+  // `update` hands the callback the real backing set, so an unmodifiable one
+  // throws from inside the callback.
+  _SetOp.action('update', (s) {
+    s.update((value) {
+      (value! as Set<int>).add(9);
+    });
+  }),
+  _SetOp('operator + returns this', (s) => identical(s + {4, 5}, s)),
+  _SetOp.action('cast view add', (s) => s.cast<num>().add(4)),
+  _SetOp.action('addIf (true)', (s) => s.addIf(true, 4)),
+  _SetOp.action(
+    'addIf (false)',
+    (s) => s.addIf(false, 4),
+    unmod: _Unmod.succeeds,
+  ),
+  _SetOp.action('addAllIf (true)', (s) => s.addAllIf(true, {4, 5})),
+  _SetOp.action('assign', (s) => s.assign(9), unmod: _Unmod.succeeds),
+  _SetOp.action(
+    'assignAll',
+    (s) => s.assignAll({7, 8}),
+    unmod: _Unmod.succeeds,
+  ),
+];
+
+final _setSequences = <_SetOp>[
+  _SetOp.action('clear, add, remove', (s) {
+    s.clear();
+    s.add(7);
+    s.remove(7);
+    s.addAll({1, 2});
+  }),
+  _SetOp.action('removeWhere, addAll, retainAll', (s) {
+    s.removeWhere((e) => e.isOdd);
+    s.addAll({4, 5, 6});
+    s.retainAll([4, 6]);
+  }),
+  _SetOp.action('assignAll, add, remove', (s) {
+    s.assignAll({5, 6});
+    s.add(7);
+    s.remove(5);
+  }, unmod: _Unmod.succeeds),
+];
+
+final _mapOps = <_MapOp>[
+  _MapOp.action('operator []= (new key)', (m) => m['c'] = 3),
+  _MapOp.action('operator []= (existing key)', (m) => m['a'] = 9),
+  _MapOp('remove (present)', (m) => m.remove('a')),
+  _MapOp('remove (absent)', (m) => m.remove('zz')),
+  _MapOp.action('addAll', (m) => m.addAll({'c': 3})),
+  _MapOp.action('addAll (empty)', (m) => m.addAll(const <String, int>{})),
+  _MapOp.action('addEntries', (m) => m.addEntries([const MapEntry('c', 3)])),
+  _MapOp('putIfAbsent (absent)', (m) => m.putIfAbsent('c', () => 3)),
+  _MapOp('putIfAbsent (present)', (m) => m.putIfAbsent('a', () => 9)),
+  _MapOp('update (present)', (m) => m.update('a', (v) => v + 1)),
+  _MapOp(
+    'update (absent, ifAbsent)',
+    (m) => m.update('c', (v) => v, ifAbsent: () => 7),
+  ),
+  _MapOp.action('updateAll', (m) => m.updateAll((key, value) => value * 2)),
+  _MapOp.action('removeWhere', (m) => m.removeWhere((key, value) => value > 1)),
+  _MapOp.action('removeWhere (no match)', (m) {
+    m.removeWhere((key, value) => value > 99);
+  }),
+  _MapOp.action('clear', (m) => m.clear()),
+  _MapOp.action('cast view write', (m) => m.cast<String, num>()['c'] = 3),
+  _MapOp.action('addIf (true)', (m) => m.addIf(true, 'c', 3)),
+  _MapOp.action(
+    'addIf (false)',
+    (m) => m.addIf(false, 'c', 3),
+    unmod: _Unmod.succeeds,
+  ),
+  _MapOp.action('addAllIf (true)', (m) => m.addAllIf(true, {'c': 3})),
+  _MapOp.action('assign', (m) => m.assign('z', 9), unmod: _Unmod.succeeds),
+  _MapOp.action(
+    'assignAll',
+    (m) => m.assignAll({'y': 8, 'z': 9}),
+    unmod: _Unmod.succeeds,
+  ),
+  // Must fail identically on every mutable backing; an unmodifiable one
+  // refuses before the ArgumentError can be raised.
+  _MapOp('update (absent, no ifAbsent)', (m) => m.update('c', (v) => v)),
+];
+
+final _mapSequences = <_MapOp>[
+  _MapOp.action('clear, write, remove', (m) {
+    m.clear();
+    m['x'] = 1;
+    m['y'] = 2;
+    m.remove('x');
+  }),
+  _MapOp.action('updateAll, addAll, removeWhere', (m) {
+    m.updateAll((key, value) => value * 10);
+    m.addAll({'c': 3});
+    m.removeWhere((key, value) => value >= 20);
+  }),
+  _MapOp.action('assignAll, write, remove', (m) {
+    m.assignAll({'x': 1, 'y': 2});
+    m['z'] = 3;
+    m.remove('x');
+  }, unmod: _Unmod.succeeds),
+];
+
+void main() {
+  // ---------------------------------------------------------------------
+  // 1. Equivalence: no immutability intent means indistinguishable.
+  // ---------------------------------------------------------------------
+
+  group(
+    'RxList over [1, 2, 3]: a fixed-length backing equals a growable one',
+    () {
+      for (final op in _listOps) {
+        test(op.name, () {
+          final control = _runList(_growableSeed(), op);
+          for (final backing in _equivalentListBackings.entries) {
+            _expectSame(
+              '${op.name} on ${backing.key}',
+              _runList(backing.value(), op),
+              control,
+            );
+          }
+        });
+      }
+    },
+  );
+
+  group(
+    'RxList over an empty fixed-length backing equals an empty growable one',
+    () {
+      for (final op in _emptyListOps) {
+        test(op.name, () {
+          final control = _runList(<int>[], op);
+          for (final backing in _equivalentEmptyListBackings.entries) {
+            _expectSame(
+              '${op.name} on ${backing.key}',
+              _runList(backing.value(), op),
+              control,
+            );
+          }
+        });
+      }
+    },
+  );
+
+  group('RxList sequences: a fixed-length backing equals a growable one', () {
+    for (final op in _listSequences) {
+      test(op.name, () {
+        final control = _runList(_growableSeed(), op);
+        for (final backing in _equivalentListBackings.entries) {
+          _expectSame(
+            '${op.name} on ${backing.key}',
+            _runList(backing.value(), op),
+            control,
+            maxNotifications: null,
+          );
+        }
+      });
+    }
+  });
+
+  group('RxSet over {1, 2, 3} behaves the same on every mutable backing', () {
+    for (final op in [..._setOps, ..._setSequences]) {
+      test(op.name, () {
+        final control = _runSet(_mutableSeed(), op);
+        for (final backing in _equivalentSetBackings.entries) {
+          _expectSame(
+            '${op.name} on ${backing.key}',
+            _runSet(backing.value(), op),
+            control,
+            maxNotifications: null,
+          );
+        }
+      });
+    }
+  });
+
+  group(
+    'RxMap over {a: 1, b: 2} behaves the same on every mutable backing',
+    () {
+      for (final op in [..._mapOps, ..._mapSequences]) {
+        test(op.name, () {
+          final control = _runMap(_mutableMapSeed(), op);
+          for (final backing in _equivalentMapBackings.entries) {
+            _expectSame(
+              '${op.name} on ${backing.key}',
+              _runMap(backing.value(), op),
+              control,
+              maxNotifications: null,
+            );
+          }
+        });
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // 2. Rejection: an unmodifiable backing is NOT equivalent, by design.
+  // ---------------------------------------------------------------------
+
+  group(
+    'RxList over an unmodifiable backing rejects what a growable one accepts',
+    () {
+      for (final op in _listOps) {
+        test(op.name, () {
+          final control = _runList(_growableSeed(), op);
+          for (final backing in _unmodifiableListBackings.entries) {
+            final label = '${op.name} on ${backing.key}';
+            if (op.unmod == _Unmod.succeeds) {
+              _expectSame(label, _runList(backing.value(), op), control);
+            } else {
+              _expectListRejects(label, backing.value(), op, _listSeed);
+            }
+          }
+        });
+      }
+    },
+  );
+
+  group('RxList over an empty unmodifiable backing rejects mutation', () {
+    for (final op in _emptyListOps) {
+      test(op.name, () {
+        final control = _runList(<int>[], op);
+        for (final backing in _unmodifiableEmptyListBackings.entries) {
+          final label = '${op.name} on ${backing.key}';
+          if (op.unmod == _Unmod.succeeds) {
+            _expectSame(label, _runList(backing.value(), op), control);
+          } else {
+            _expectListRejects(label, backing.value(), op, const <int>[]);
+          }
+        }
+      });
+    }
+  });
+
+  group('RxList sequences over an unmodifiable backing are rejected', () {
+    for (final op in _listSequences) {
+      test(op.name, () {
+        final control = _runList(_growableSeed(), op);
+        for (final backing in _unmodifiableListBackings.entries) {
+          final label = '${op.name} on ${backing.key}';
+          if (op.unmod == _Unmod.succeeds) {
+            _expectSame(
+              label,
+              _runList(backing.value(), op),
+              control,
+              maxNotifications: null,
+            );
+          } else {
+            _expectListRejects(label, backing.value(), op, _listSeed);
+          }
+        }
+      });
+    }
+  });
+
+  group('RxSet over an unmodifiable backing rejects mutation', () {
+    for (final op in [..._setOps, ..._setSequences]) {
+      test(op.name, () {
+        final control = _runSet(_mutableSeed(), op);
+        for (final backing in _unmodifiableSetBackings.entries) {
+          final label = '${op.name} on ${backing.key}';
+          if (op.unmod == _Unmod.succeeds) {
+            _expectSame(
+              label,
+              _runSet(backing.value(), op),
+              control,
+              maxNotifications: null,
+            );
+          } else {
+            _expectSetRejects(label, backing.value(), op);
+          }
+        }
+      });
+    }
+  });
+
+  group('RxMap over an unmodifiable backing rejects mutation', () {
+    for (final op in [..._mapOps, ..._mapSequences]) {
+      test(op.name, () {
+        final control = _runMap(_mutableMapSeed(), op);
+        for (final backing in _unmodifiableMapBackings.entries) {
+          final label = '${op.name} on ${backing.key}';
+          if (op.unmod == _Unmod.succeeds) {
+            _expectSame(
+              label,
+              _runMap(backing.value(), op),
+              control,
+              maxNotifications: null,
+            );
+          } else {
+            _expectMapRejects(label, backing.value(), op);
+          }
+        }
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // 3. The two invariants, stated as duals.
+  // ---------------------------------------------------------------------
+
+  group('healing is idempotently unsticking', () {
+    test('no RxList operation leaves a list that rejects a later add', () {
+      final ops = [..._listOps, ..._listSequences];
+      for (final backing in _equivalentListBackings.entries) {
+        for (final op in ops) {
+          final label = '${op.name} on ${backing.key}';
+          final rx = RxList<int>(backing.value());
+          try {
+            op.run(rx);
+          } catch (_) {
+            // Operations that are meant to throw must leave a usable list too.
+          }
+          expect(() => rx.add(999), returnsNormally, reason: label);
+          expect(rx.last, 999, reason: label);
+          expect(
+            () {
+              rx.insert(0, -1);
+              rx.removeAt(0);
+              rx.removeLast();
+              rx.clear();
+              rx.addAll([1, 2]);
+              rx[0] = 3;
+              rx.sort();
+            },
+            returnsNormally,
+            reason: label,
+          );
+          expect(rx, [2, 3], reason: label);
+        }
+      }
+    });
+
+    test('no RxList operation leaves an empty list stuck', () {
+      for (final backing in _equivalentEmptyListBackings.entries) {
+        for (final op in _emptyListOps) {
+          final label = '${op.name} on ${backing.key}';
+          final rx = RxList<int>(backing.value());
+          try {
+            op.run(rx);
+          } catch (_) {
+            // See above.
+          }
+          expect(
+            () {
+              rx.clear();
+              rx.add(1);
+              rx.insert(0, 0);
+            },
+            returnsNormally,
+            reason: label,
+          );
+          expect(rx, [0, 1], reason: label);
+        }
+      }
+    });
+
+    test(
+      'no RxSet operation leaves a mutable set that rejects a later add',
+      () {
+        for (final backing in _equivalentSetBackings.entries) {
+          for (final op in [..._setOps, ..._setSequences]) {
+            final label = '${op.name} on ${backing.key}';
+            final rx = RxSet<int>(backing.value());
+            try {
+              op.run(rx);
+            } catch (_) {
+              // See above.
+            }
+            expect(
+              () {
+                rx.add(999);
+                rx.remove(999);
+                rx.clear();
+                rx.addAll({1, 2});
+              },
+              returnsNormally,
+              reason: label,
+            );
+            expect(rx, {1, 2}, reason: label);
+          }
+        }
+      },
+    );
+
+    test(
+      'no RxMap operation leaves a mutable map that rejects a later write',
+      () {
+        for (final backing in _equivalentMapBackings.entries) {
+          for (final op in [..._mapOps, ..._mapSequences]) {
+            final label = '${op.name} on ${backing.key}';
+            final rx = RxMap<String, int>(backing.value());
+            try {
+              op.run(rx);
+            } catch (_) {
+              // See above.
+            }
+            expect(
+              () {
+                rx['zz'] = 1;
+                rx.remove('zz');
+                rx.clear();
+                rx.addAll({'k': 1});
+              },
+              returnsNormally,
+              reason: label,
+            );
+            expect(rx, {'k': 1}, reason: label);
+          }
+        }
+      },
+    );
+  });
+
+  group('unmodifiable is forever', () {
+    // The dual invariant. `_expectListRejects` already asserts this per
+    // operation; these tests state it once more as the standalone property,
+    // including for the `assign`/`assignAll` seam, which is the *only* way an
+    // unmodifiable backing is ever legitimately replaced.
+    test('a rejected RxList mutation never swaps the backing', () {
+      for (final backing in _unmodifiableListBackings.entries) {
+        for (final op in [..._listOps, ..._listSequences]) {
+          if (op.unmod == _Unmod.succeeds) continue;
+          final label = '${op.name} on ${backing.key}';
+          final original = backing.value();
+          final rx = RxList<int>(original);
+          try {
+            op.run(rx);
+          } on UnsupportedError {
+            // Expected; asserted exhaustively by the rejection group above.
+          }
+          expect(
+            identical(rx.value, original),
+            isTrue,
+            reason: '$label: the probe must have had no side effect',
+          );
+          expect(() => rx.add(999), throwsUnsupportedError, reason: label);
+          expect(rx, _listSeed, reason: label);
+        }
+      }
+    });
+
+    test('a rejected RxSet/RxMap mutation never swaps the backing', () {
+      for (final backing in _unmodifiableSetBackings.entries) {
+        for (final op in [..._setOps, ..._setSequences]) {
+          if (op.unmod == _Unmod.succeeds) continue;
+          final original = backing.value();
+          final rx = RxSet<int>(original);
+          try {
+            op.run(rx);
+          } on UnsupportedError {
+            // Expected.
+          }
+          expect(identical(rx.value, original), isTrue, reason: op.name);
+          expect(() => rx.add(999), throwsUnsupportedError, reason: op.name);
+        }
+      }
+      for (final backing in _unmodifiableMapBackings.entries) {
+        for (final op in [..._mapOps, ..._mapSequences]) {
+          if (op.unmod == _Unmod.succeeds) continue;
+          final original = backing.value();
+          final rx = RxMap<String, int>(original);
+          try {
+            op.run(rx);
+          } on UnsupportedError {
+            // Expected.
+          }
+          expect(identical(rx.value, original), isTrue, reason: op.name);
+          expect(() => rx['zz'] = 1, throwsUnsupportedError, reason: op.name);
+        }
+      }
+    });
+
+    test('assign/assignAll is the only escape, and it is a fresh backing', () {
+      final backing = List<int>.unmodifiable(_listSeed);
+      final rx = RxList<int>(backing);
+
+      expect(() => rx.add(4), throwsUnsupportedError);
+      rx.assignAll([7, 8]);
+
+      expect(
+        identical(rx.value, backing),
+        isFalse,
+        reason: 'assignAll publishes a new, growable backing list',
+      );
+      expect(backing, _listSeed, reason: 'the old backing is untouched');
+      // And from here on the RxList is an ordinary growable one.
+      expect(() => rx.add(9), returnsNormally);
+      expect(rx, [7, 8, 9]);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 4. Aliasing: heal exactly when required and never more.
+  // ---------------------------------------------------------------------
+
+  group('aliasing and copying are only as aggressive as they must be', () {
+    test('a growable backing is still mutated in place', () {
+      final backing = <int>[1, 2, 3];
+      final rx = RxList<int>(backing);
+
+      rx.add(4);
+      rx.sort((a, b) => b.compareTo(a));
+
+      expect(identical(rx.value, backing), isTrue);
+      expect(backing, [4, 3, 2, 1]);
+    });
+
+    test('a fixed-length backing is still written in place by element ops', () {
+      final backing = List<int>.of(_listSeed, growable: false);
+      final rx = RxList<int>(backing);
+
+      rx.sort((a, b) => b.compareTo(a));
+      rx[2] = 0;
+      rx.shuffle(Random(1));
+      rx.fillRange(0, 1, 5);
+      rx.setAll(1, [6]);
+      rx.setRange(2, 3, [7]);
+
+      expect(
+        identical(rx.value, backing),
+        isTrue,
+        reason: 'element writes must not detach a fixed-length backing',
+      );
+      expect(rx, backing, reason: 'the writes landed in the caller list');
+    });
+
+    test('a Uint8List backing stays aliased under element writes', () {
+      // The canonical "fixed-length but very much writable" buffer.
+      final backing = Uint8List.fromList(_listSeed);
+      final rx = RxList<int>(backing);
+
+      rx[0] = 9;
+      rx.sort();
+      rx.fillRange(0, 1, 4);
+
+      expect(identical(rx.value, backing), isTrue);
+      expect(backing, [4, 3, 9]);
+
+      // ...and heals, detaching, on the first length change.
+      rx.add(5);
+      expect(identical(rx.value, backing), isFalse);
+      expect(backing, [4, 3, 9], reason: 'the buffer is left as it was');
+      expect(rx, [4, 3, 9, 5]);
+    });
+
+    test('a length change detaches a fixed-length backing exactly once', () {
+      final backing = List<int>.of(_listSeed, growable: false);
+      final rx = RxList<int>(backing);
+
+      rx.add(4);
+      final swapped = rx.value;
+      rx.add(5);
+
+      expect(backing, _listSeed, reason: 'the caller list must be untouched');
+      expect(
+        identical(rx.value, swapped),
+        isTrue,
+        reason: 'the growable copy must be reused, not re-copied',
+      );
+      expect(rx, [1, 2, 3, 4, 5]);
+    });
+
+    test('an unmodifiable backing is never written to, and never swapped', () {
+      final source = <int>[1, 2, 3];
+      final backing = List<int>.unmodifiable(source);
+      final rx = RxList<int>(backing);
+      final notifications = _watch(rx);
+
+      expect(() => rx.sort((a, b) => b.compareTo(a)), throwsUnsupportedError);
+      expect(() => rx.add(4), throwsUnsupportedError);
+      expect(() => rx[0] = 9, throwsUnsupportedError);
+
+      expect(backing, [1, 2, 3]);
+      expect(source, [1, 2, 3]);
+      expect(rx, [1, 2, 3]);
+      expect(identical(rx.value, backing), isTrue);
+      expect(notifications(), 0);
+    });
+
+    test('an unmodifiable set/map backing is never written to', () {
+      final setBacking = Set<int>.unmodifiable(_setSeed);
+      final mapBacking = Map<String, int>.unmodifiable(_mapSeed);
+      final rxSet = RxSet<int>(setBacking);
+      final rxMap = RxMap<String, int>(mapBacking);
+      final setNotifications = _watch(rxSet);
+      final mapNotifications = _watch(rxMap);
+
+      expect(() => rxSet.add(4), throwsUnsupportedError);
+      expect(() => rxMap['c'] = 3, throwsUnsupportedError);
+
+      expect(setBacking, _setSeed);
+      expect(mapBacking, _mapSeed);
+      expect(rxSet, _setSeed);
+      expect(rxMap, _mapSeed);
+      expect(identical(rxSet.value, setBacking), isTrue);
+      expect(identical(rxMap.value, mapBacking), isTrue);
+      expect(setNotifications(), 0);
+      expect(mapNotifications(), 0);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 5. Errors are never swallowed, on either path.
+  // ---------------------------------------------------------------------
+
+  group('failures are reported, not swallowed', () {
+    test('an UnsupportedError from a user comparator propagates', () {
+      for (final backing in _equivalentListBackings.entries) {
+        final rx = RxList<int>(backing.value());
+        final notifications = _watch(rx);
+
+        expect(
+          () => rx.sort((a, b) => throw UnsupportedError('from the callback')),
+          throwsUnsupportedError,
+          reason: backing.key,
+        );
+        // Only the capability probes may catch an UnsupportedError.
+        expect(notifications(), 0, reason: backing.key);
+      }
+    });
+
+    test('an unmodifiable backing refuses sort before the comparator runs', () {
+      for (final backing in _unmodifiableListBackings.entries) {
+        final rx = RxList<int>(backing.value());
+        final notifications = _watch(rx);
+        var comparatorCalls = 0;
+
+        expect(
+          () => rx.sort((a, b) {
+            comparatorCalls++;
+            return a.compareTo(b);
+          }),
+          throwsUnsupportedError,
+          reason: backing.key,
+        );
+        expect(comparatorCalls, 0, reason: backing.key);
+        expect(notifications(), 0, reason: backing.key);
+        expect(rx, _listSeed, reason: backing.key);
+      }
+    });
+
+    test('a throwing predicate leaves the list untouched', () {
+      for (final backing in _equivalentListBackings.entries) {
+        final rx = RxList<int>(backing.value());
+        final notifications = _watch(rx);
+
+        expect(
+          () => rx.removeWhere((e) => throw StateError('boom')),
+          throwsStateError,
+          reason: backing.key,
+        );
+        expect(rx, _listSeed, reason: backing.key);
+        expect(notifications(), 0, reason: backing.key);
+      }
+    });
+
+    test('a throwing predicate over an unmodifiable list never runs', () {
+      for (final backing in _unmodifiableListBackings.entries) {
+        final rx = RxList<int>(backing.value());
+        final notifications = _watch(rx);
+
+        // The backing refuses first, so the StateError is never reached.
+        expect(
+          () => rx.removeWhere((e) => throw StateError('boom')),
+          throwsUnsupportedError,
+          reason: backing.key,
+        );
+        expect(rx, _listSeed, reason: backing.key);
+        expect(notifications(), 0, reason: backing.key);
+      }
+    });
+
+    test('a throwing map callback leaves the map untouched', () {
+      for (final backing in _equivalentMapBackings.entries) {
+        final rx = RxMap<String, int>(backing.value());
+        final notifications = _watch(rx);
+
+        expect(
+          () => rx.updateAll((key, value) => throw StateError('boom')),
+          throwsStateError,
+          reason: backing.key,
+        );
+        expect(rx, _mapSeed, reason: backing.key);
+        expect(notifications(), 0, reason: backing.key);
+      }
+    });
+
+    test('an unmodifiable map refuses updateAll before the callback runs', () {
+      for (final backing in _unmodifiableMapBackings.entries) {
+        final rx = RxMap<String, int>(backing.value());
+        final notifications = _watch(rx);
+
+        expect(
+          () => rx.updateAll((key, value) => throw StateError('boom')),
+          throwsUnsupportedError,
+          reason: backing.key,
+        );
+        expect(rx, _mapSeed, reason: backing.key);
+        expect(notifications(), 0, reason: backing.key);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 6. The copies that do happen keep the backing's runtime element type.
+  // ---------------------------------------------------------------------
+
+  group('covariance survives the copy', () {
+    test('a healed fixed-length List<int> backing still rejects a double', () {
+      for (final backing in <String, List<num> Function()>{
+        'List.of growable: false': () =>
+            List<int>.of(_listSeed, growable: false),
+        'Uint8List': () => Uint8List.fromList(_listSeed),
+      }.entries) {
+        final rx = RxList<num>(backing.value());
+
+        rx.removeAt(0);
+
+        expect(rx, [2, 3], reason: backing.key);
+        expect(
+          () => rx.add(0.5),
+          throwsA(isA<TypeError>()),
+          reason: '${backing.key}: the copy must keep the runtime element type',
+        );
+      }
+    });
+
+    test('an assignAll copy of a List<int> backing still rejects a double', () {
+      final rx = RxList<num>(List<int>.unmodifiable(_listSeed));
+
+      // The mutator path is closed...
+      expect(() => rx.removeAt(0), throwsUnsupportedError);
+      // ...but assignAll replaces the contents wholesale, and its copy keeps
+      // the backing's runtime element type just like the healing copy does —
+      // so the copy is a List<int> and refuses a List<num> outright.
+      expect(() => rx.assignAll(<num>[2, 3]), throwsA(isA<TypeError>()));
+      rx.assignAll(<int>[2, 3]);
+
+      expect(rx, [2, 3]);
+      expect(() => rx.add(0.5), throwsA(isA<TypeError>()));
+    });
+
+    test('an assignAll copy of a Set<int> backing still rejects a double', () {
+      final rx = RxSet<num>(Set<int>.unmodifiable(_setSeed));
+
+      expect(() => rx.remove(1), throwsUnsupportedError);
+      expect(() => rx.assignAll(<num>{2, 3}), throwsA(isA<TypeError>()));
+      rx.assignAll(<int>{2, 3});
+
+      expect(rx, {2, 3});
+      expect(() => rx.add(0.5), throwsA(isA<TypeError>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 7. Nested Rx backings and the broadcast stream.
+  // ---------------------------------------------------------------------
+
+  group('nested Rx backings are short-circuited, not probed', () {
+    test('mutating the outer list notifies the inner one exactly once', () {
+      final inner = RxList<int>(_growableSeed());
+      final outer = RxList<int>(inner);
+      final innerCount = _watch(inner);
+      final outerCount = _watch(outer);
+
+      outer.add(4);
+      outer.sort((a, b) => b.compareTo(a));
+
+      expect(outer, [4, 3, 2, 1]);
+      expect(inner, [4, 3, 2, 1]);
+      expect(outerCount(), 2);
+      expect(innerCount(), 2, reason: 'the probes must not notify');
+    });
+
+    test('an inner RxList applies its own policy to the outer mutation', () {
+      // The outer list short-circuits the probes and hands the action to the
+      // inner RxList, which heals or throws exactly as it would standalone.
+      final healing = RxList<int>(RxList<int>(List<int>.empty()));
+      healing.add(1);
+      expect(healing, [1]);
+
+      final frozen = RxList<int>(
+        RxList<int>(List<int>.unmodifiable(_listSeed)),
+      );
+      expect(() => frozen.add(4), throwsUnsupportedError);
+      expect(frozen, _listSeed);
+    });
+
+    test('mutating the outer set/map notifies the inner one exactly once', () {
+      final innerSet = RxSet<int>(_mutableSeed());
+      final outerSet = RxSet<int>(innerSet);
+      final innerSetCount = _watch(innerSet);
+      outerSet.add(4);
+      expect(innerSetCount(), 1);
+
+      final innerMap = RxMap<String, int>(_mutableMapSeed());
+      final outerMap = RxMap<String, int>(innerMap);
+      final innerMapCount = _watch(innerMap);
+      outerMap['c'] = 3;
+      expect(innerMapCount(), 1);
+    });
+  });
+
+  group('the broadcast stream agrees with the listener count', () {
+    test('one stream event per mutation of a fixed-length backing', () async {
+      final RxList<int> rx = List<int>.empty().obs;
+      var events = 0;
+      rx.listen((_) => events++);
+      // The stream event *is* the live backing list, and the broadcast
+      // controller delivers in a later microtask, so every delivered event
+      // points at the same (final) list. Snapshot synchronously instead.
+      final snapshots = <List<int>>[];
+      rx.addListener(() => snapshots.add(rx.toList()));
+
+      rx.insert(0, 1);
+      rx.insert(0, 2);
+      rx.clear();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, 3);
+      expect(snapshots, [
+        [1],
+        [2, 1],
+        <int>[],
+      ]);
+    });
+
+    test('one stream event per mutation of a mutable map', () async {
+      final rx = RxMap<String, int>(_mutableMapSeed());
+      var events = 0;
+      rx.listen((_) => events++);
+
+      rx['c'] = 3;
+      rx.remove('a');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, 2);
+      expect(rx, {'b': 2, 'c': 3});
+    });
+
+    test('a rejected mutation produces no stream event at all', () async {
+      final rx = RxMap<String, int>(Map<String, int>.unmodifiable(_mapSeed));
+      var events = 0;
+      rx.listen((_) => events++);
+
+      expect(() => rx['c'] = 3, throwsUnsupportedError);
+      expect(() => rx.remove('a'), throwsUnsupportedError);
+      expect(() => rx.clear(), throwsUnsupportedError);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, 0);
+      expect(rx, _mapSeed);
+    });
+
+    test(
+      'assignAll over an unmodifiable backing emits exactly one event',
+      () async {
+        final rx = RxMap<String, int>(Map<String, int>.unmodifiable(_mapSeed));
+        var events = 0;
+        rx.listen((_) => events++);
+
+        rx.assignAll({'z': 9});
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, 1);
+        expect(rx, {'z': 9});
+      },
+    );
+  });
+}

--- a/test/rx/rx_collection_probe_hardening_test.dart
+++ b/test/rx/rx_collection_probe_hardening_test.dart
@@ -1,0 +1,740 @@
+// Hardening tests for `RxList`'s capability probes — the pair of no-op writes
+// that decide which of the three backing shapes it is holding:
+//
+//   `_canChangeLength`  : `list.length = list.length`
+//   `_canWriteElements` : `list[0] = list[0]`, or `setRange(0, 0, const [])`
+//                         when the list is empty and there is no element to
+//                         overwrite
+//
+//   canChangeLength | canWriteElements | classification | length-op behaviour
+//   ----------------|------------------|----------------|--------------------
+//        true       |   (not probed)   | growable       | in place
+//        false      |      true        | fixed-length   | HEALS to a copy
+//        false      |      false       | unmodifiable   | THROWS
+//
+// `_canWriteElements` is what makes the second and third rows different, so it
+// is load-bearing: collapse it away and either `List.empty().obs.add(x)` starts
+// throwing again, or `List.unmodifiable([...]).obs.add(x)` silently succeeds.
+// Both are pinned below, on `dart:core` types and on `ListBase` subclasses
+// that reject mutation only through the abstract primitives.
+//
+// Note what is NOT here any more: `RxSet` and `RxMap` do not probe at all.
+// `dart:core` has no fixed-length-but-writable Set or Map, so "unmodifiable"
+// was their only failure mode; under the narrow contract that is an honoured
+// opt-in, there is nothing to heal, and the `remove(_mutationProbe)` sentinel
+// they used to need is gone. The tests that covered that sentinel went with
+// it; what remains for them is the inverse assertion — they throw.
+import 'dart:collection';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:getxify/getxify.dart';
+
+// ---------------------------------------------------------------------------
+// Collections that reject mutation by overriding ONLY the abstract primitives
+// of SetBase/MapBase/ListBase, inheriting every derived member from the mixin.
+// ---------------------------------------------------------------------------
+
+class NaiveUnmodifiableSet<E> extends SetBase<E> {
+  NaiveUnmodifiableSet(this._inner);
+
+  final Set<E> _inner;
+
+  @override
+  bool add(E value) => throw UnsupportedError('unmodifiable');
+
+  @override
+  bool remove(Object? value) => throw UnsupportedError('unmodifiable');
+
+  @override
+  bool contains(Object? element) => _inner.contains(element);
+
+  @override
+  Iterator<E> get iterator => _inner.iterator;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  E? lookup(Object? element) => _inner.lookup(element);
+
+  @override
+  Set<E> toSet() => _inner.toSet();
+}
+
+class NaiveUnmodifiableMap<K, V> extends MapBase<K, V> {
+  NaiveUnmodifiableMap(this._inner);
+
+  final Map<K, V> _inner;
+
+  @override
+  V? operator [](Object? key) => _inner[key];
+
+  @override
+  void operator []=(K key, V value) => throw UnsupportedError('unmodifiable');
+
+  @override
+  void clear() => throw UnsupportedError('unmodifiable');
+
+  @override
+  V? remove(Object? key) => throw UnsupportedError('unmodifiable');
+
+  @override
+  Iterable<K> get keys => _inner.keys;
+}
+
+/// A list that rejects BOTH length changes and element writes: unmodifiable.
+class NaiveUnmodifiableList<E> extends ListBase<E> {
+  NaiveUnmodifiableList(this._inner);
+
+  final List<E> _inner;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) => throw UnsupportedError('unmodifiable');
+
+  @override
+  E operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, E value) =>
+      throw UnsupportedError('unmodifiable');
+}
+
+/// A list that rejects length changes but accepts element writes: the
+/// hand-rolled equivalent of `List.filled` / a `Uint8List`. This is the shape
+/// [NaiveUnmodifiableList] has to be told apart from, and `_canWriteElements`
+/// is the only thing that can do it.
+class NaiveFixedLengthList<E> extends ListBase<E> {
+  NaiveFixedLengthList(this._inner);
+
+  final List<E> _inner;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) => throw UnsupportedError('fixed-length');
+
+  @override
+  E operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, E value) {
+    _inner[index] = value;
+  }
+}
+
+/// A list whose length setter is simply not implemented — it throws something
+/// that is NOT an [UnsupportedError] — but whose `add` works perfectly well.
+/// The probe must not turn its own no-op write into the caller's crash.
+class UnimplementedLengthList<E> extends ListBase<E> {
+  UnimplementedLengthList(this._inner);
+
+  final List<E> _inner;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) => throw StateError('length setter unsupported');
+
+  @override
+  E operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, E value) {
+    _inner[index] = value;
+  }
+
+  @override
+  void add(E element) {
+    _inner.add(element);
+  }
+}
+
+/// Fixed-length, and its `[]=` rejects writes with something that is NOT an
+/// [UnsupportedError]. The element probe must swallow that rather than let it
+/// escape ahead of the real mutation.
+class HostileElementWriteList<E> extends ListBase<E> {
+  HostileElementWriteList(this._inner);
+
+  final List<E> _inner;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) => throw UnsupportedError('fixed-length');
+
+  @override
+  E operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, E value) => throw StateError('no writes here');
+}
+
+/// Fixed-length, and its `==` claims equality with any other list. Assigning a
+/// growable copy over it must not be mistaken for "nothing changed".
+class LyingEqualityList extends ListBase<int> {
+  LyingEqualityList(this._inner);
+
+  final List<int> _inner;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) => throw UnsupportedError('fixed-length');
+
+  @override
+  int operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, int value) {
+    _inner[index] = value;
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) => other is List<int>;
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => 0;
+}
+
+/// A growable list that counts every element write it is asked to perform,
+/// so the probes' cost is observable.
+class WriteCountingList<E> extends ListBase<E> {
+  WriteCountingList(this._inner);
+
+  final List<E> _inner;
+  int writes = 0;
+  int lengthWrites = 0;
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  set length(int newLength) {
+    lengthWrites++;
+    _inner.length = newLength;
+  }
+
+  @override
+  E operator [](int index) => _inner[index];
+
+  @override
+  void operator []=(int index, E value) {
+    writes++;
+    _inner[index] = value;
+  }
+}
+
+void main() {
+  group('_canWriteElements discriminates fixed-length from unmodifiable', () {
+    test('dart:core fixed-length backings heal on a length change', () {
+      for (final backing in <List<int>>[
+        List<int>.filled(2, 0)..setAll(0, [1, 2]),
+        Uint8List.fromList([1, 2]),
+      ]) {
+        final rx = RxList<int>(backing);
+
+        expect(() => rx.add(3), returnsNormally);
+        expect(rx, [1, 2, 3]);
+        expect(
+          identical(rx.value, backing),
+          isFalse,
+          reason: 'the heal detaches from the caller\'s buffer',
+        );
+        expect(backing, [1, 2], reason: 'which is left untouched');
+      }
+    });
+
+    test('dart:core unmodifiable backings throw on a length change', () {
+      for (final backing in <List<int>>[
+        List<int>.unmodifiable([1, 2]),
+        const <int>[1, 2],
+        UnmodifiableListView<int>(<int>[1, 2]),
+      ]) {
+        final rx = RxList<int>(backing);
+
+        expect(() => rx.add(3), throwsUnsupportedError);
+        expect(rx, [1, 2]);
+        expect(identical(rx.value, backing), isTrue);
+      }
+    });
+
+    test('ListBase subclass that only rejects length= heals', () {
+      final inner = <int>[1, 2];
+      final rx = RxList<int>(NaiveFixedLengthList<int>(inner));
+
+      expect(() => rx.add(3), returnsNormally);
+      expect(rx, [1, 2, 3]);
+      expect(inner, [1, 2], reason: 'the heal copied instead of mutating');
+
+      // Element writes on such a backing still land in place, before any
+      // length change detaches it.
+      final other = NaiveFixedLengthList<int>(<int>[3, 1, 2]);
+      final rxOther = RxList<int>(other);
+      expect(() => rxOther.sort(), returnsNormally);
+      expect(identical(rxOther.value, other), isTrue);
+      expect(other, [1, 2, 3]);
+    });
+
+    test('ListBase subclass that rejects length= AND []= throws', () {
+      // The probe has to reach the member that decides mutability: `add` is a
+      // *derived* member (`ListBase.add` grows through `length=`), so nothing
+      // but a real capability probe can tell this apart from the fixed-length
+      // class above.
+      final rx = RxList<int>(NaiveUnmodifiableList<int>([1, 2]));
+
+      expect(() => rx.add(3), throwsUnsupportedError);
+      expect(rx, [1, 2]);
+
+      final other = RxList<int>(NaiveUnmodifiableList<int>([3, 1, 2]));
+      expect(() => other.sort(), throwsUnsupportedError);
+      expect(other, [3, 1, 2]);
+    });
+
+    test('the empty-list branch decides List.empty().obs', () {
+      // With no element to overwrite, `_canWriteElements` probes
+      // `setRange(0, 0, const [])` instead. Falling back to the *length* probe
+      // here would answer `false` for a fixed-length list too, and
+      // `List.empty().obs.add(x)` — the reported crash — would still throw.
+      final healed = List<int>.empty().obs;
+      expect(() => healed.add(1), returnsNormally);
+      expect(healed, [1]);
+
+      final emptyUint8 = RxList<int>(Uint8List(0));
+      expect(() => emptyUint8.add(1), returnsNormally);
+      expect(emptyUint8, [1]);
+
+      // And it must not answer `true` for an empty *unmodifiable* list: every
+      // dart:core unmodifiable list rejects even a vacuous setRange.
+      for (final backing in <List<int>>[
+        const <int>[],
+        List<int>.unmodifiable(const <int>[]),
+        UnmodifiableListView<int>(<int>[]),
+      ]) {
+        final frozen = RxList<int>(backing);
+        expect(() => frozen.add(1), throwsUnsupportedError);
+        expect(frozen, isEmpty);
+        expect(identical(frozen.value, backing), isTrue);
+      }
+    });
+
+    test('an empty unmodifiable typed-data view is not healed', () {
+      // `setRange` alone cannot see this one: an unmodifiable typed-data view
+      // only rejects writes that actually touch an element, so it accepts a
+      // vacuous range just like a plain fixed-length list does. The probe
+      // therefore looks at the underlying buffer instead — which is where the
+      // immutability actually lives — whenever there is a byte in it to probe.
+      final source = Uint8List.fromList(<int>[1, 2, 3, 4]);
+      for (final backing in <List<int>>[
+        Uint8List.sublistView(source, 2, 2).asUnmodifiableView(),
+        Int32List.sublistView(Int32List(4), 2, 2).asUnmodifiableView(),
+      ]) {
+        expect(backing, isEmpty, reason: 'the empty branch is what is probed');
+        final frozen = RxList<int>(backing);
+        expect(() => frozen.add(1), throwsUnsupportedError);
+        expect(frozen, isEmpty);
+        expect(identical(frozen.value, backing), isTrue);
+      }
+      expect(source, [1, 2, 3, 4], reason: 'the probe writes nothing');
+
+      // The mutable controls over the very same shape still heal.
+      for (final backing in <List<int>>[
+        Uint8List.sublistView(Uint8List(4), 2, 2),
+        Int32List.sublistView(Int32List(4), 2, 2),
+      ]) {
+        final healed = RxList<int>(backing);
+        expect(() => healed.add(1), returnsNormally);
+        expect(healed, [1]);
+      }
+    });
+
+    test('an unmodifiable typed-data view over a ZERO-length buffer heals', () {
+      // Documented limit. `Uint8List(0)` owns a zero-byte buffer, so there
+      // is no byte anywhere — in the list or behind it — to attempt a write
+      // against, and the view is indistinguishable from the plain
+      // `Uint8List(0)` pinned above, which must heal. Nothing can be stored
+      // in either, so nothing is at risk of being overwritten; the answer is
+      // the same on the VM and on the web, which the `setRange` probe alone
+      // could not manage.
+      final rx = RxList<int>(Uint8List(0).asUnmodifiableView());
+
+      expect(() => rx.add(7), returnsNormally);
+      expect(rx, [7]);
+    });
+
+    test(
+      'an EMPTY naive unmodifiable list is indistinguishable, and heals',
+      () {
+        // Documented limit of probing rather than type-checking.
+        // `ListMixin.setRange` returns early when the range is empty, without
+        // ever touching `[]=`, so a `ListBase` subclass that rejects mutation
+        // *only* through `length=`/`[]=` looks exactly like an empty
+        // fixed-length list — there is no observable difference to probe for.
+        // It heals.
+        //
+        // Scope of the limitation, precisely: every `dart:core` unmodifiable
+        // list (`List.unmodifiable`, `const []`, `UnmodifiableListView`)
+        // overrides `setRange` to throw unconditionally and so is classified
+        // correctly even when empty, as the test above pins. Unmodifiable
+        // *typed-data* views do NOT — they accept a vacuous range — which is
+        // why the probe falls back to their underlying buffer; only a
+        // zero-length buffer is beyond it. This branch is the residue: a
+        // hand-rolled `ListBase` that is empty and inherits `setRange`.
+        final rx = RxList<int>(NaiveUnmodifiableList<int>(<int>[]));
+
+        expect(() => rx.add(1), returnsNormally);
+        expect(rx, [1]);
+      },
+    );
+
+    test('a growable backing costs exactly one extra length write', () {
+      // `_canChangeLength` answers first and short-circuits, so the second
+      // probe's no-op `[]=` never happens on the common path. Calibrated
+      // against the same mutation performed without an RxList in the picture,
+      // because `ListBase.add` does its own `length=` and `[]=`.
+      // The element type is nullable because `ListBase.add` grows through
+      // `length = length + 1`, which pads with nulls before writing.
+      final baseline = WriteCountingList<int?>(<int?>[1, 2])..add(3);
+
+      final counting = WriteCountingList<int?>(<int?>[1, 2]);
+      RxList<int?>(counting).add(3);
+
+      expect(counting, [1, 2, 3]);
+      expect(
+        counting.writes,
+        baseline.writes,
+        reason: 'no element probe on a growable list',
+      );
+      expect(
+        counting.lengthWrites,
+        baseline.lengthWrites + 1,
+        reason: 'the single `length = length` probe, and nothing else',
+      );
+    });
+
+    test('element operations do not probe at all', () {
+      // Under the narrow contract element writes are plain in-place
+      // mutations, so a write-observing backing sees exactly the writes the
+      // caller asked for.
+      final counting = WriteCountingList<int>(<int>[1, 2, 3]);
+      final rx = RxList<int>(counting);
+
+      rx[0] = 9;
+
+      expect(counting.writes, 1);
+      expect(counting.lengthWrites, 0);
+      expect(rx, [9, 2, 3]);
+    });
+
+    test('probing leaves the backing\'s contents untouched', () {
+      final backing = List<int>.filled(3, 0)..setAll(0, [1, 2, 3]);
+      final rx = RxList<int>(backing);
+
+      // Probes, then heals. Neither probe may perturb the values.
+      rx.add(4);
+
+      expect(backing, [1, 2, 3]);
+      expect(rx, [1, 2, 3, 4]);
+    });
+  });
+
+  group('the probes are total: they never become the caller\'s error', () {
+    test('a length setter that throws a StateError still routes in place', () {
+      // The probe asks a question the caller never asked; if the backing
+      // answers with something other than UnsupportedError the probe cannot
+      // classify it, and the only safe answer is "behave as if there were no
+      // probe at all" — i.e. run the mutation straight against the backing.
+      // Here `add` is implemented and works, so it must keep working.
+      final rx = RxList<int>(UnimplementedLengthList<int>(<int>[1, 2]));
+
+      expect(() => rx.add(9), returnsNormally);
+      expect(rx, [1, 2, 9]);
+    });
+
+    test('an element setter that throws a StateError still routes in '
+        'place', () {
+      // Same rule on the second probe, except that "no probe at all" means
+      // the *unmodifiable* branch: the action runs against the backing and
+      // whatever the backing throws is what the caller sees. `ListBase.add`
+      // grows through `length=`, so that is UnsupportedError here — exactly
+      // what this call did before healing existed.
+      final rx = RxList<int>(HostileElementWriteList<int>(<int>[1, 2]));
+
+      expect(() => rx.add(9), throwsUnsupportedError);
+      expect(rx, [1, 2]);
+    });
+  });
+
+  group('the heal path is a backing swap, not a value change', () {
+    test('a backing whose == lies cannot silently swallow the heal', () async {
+      // `value = copy` short-circuits when the old value reports itself `==`
+      // to the new one. That is right for a value change and catastrophic for
+      // a backing swap: the mutation already applied to the copy would be
+      // discarded while a notification still claimed something happened.
+      final backing = LyingEqualityList(<int>[1, 2]);
+      expect(backing == <int>[9, 9, 9], isTrue, reason: 'the premise');
+
+      final rx = RxList<int>(backing);
+      var notifications = 0;
+      rx.listen((_) => notifications++);
+
+      rx.add(9);
+      await Future.delayed(Duration.zero);
+
+      expect(rx.toList(), [1, 2, 9], reason: 'the mutation must not be lost');
+      expect(rx.length, 3);
+      expect(identical(rx.value, backing), isFalse);
+      expect(backing, [1, 2], reason: 'the caller\'s list is left alone');
+      expect(notifications, 1);
+    });
+  });
+
+  group('RxSet/RxMap no longer probe, and no longer heal', () {
+    test('SetBase subclass that only overrides add/remove throws', () {
+      final rx = RxSet<int>(NaiveUnmodifiableSet<int>({1, 2}));
+
+      expect(() => rx.add(3), throwsUnsupportedError);
+      expect(rx, unorderedEquals(<int>[1, 2]));
+
+      expect(
+        () => RxSet<int>(NaiveUnmodifiableSet<int>({1, 2})).clear(),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => RxSet<int>(NaiveUnmodifiableSet<int>({1, 2})).remove(1),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => RxSet<int>(NaiveUnmodifiableSet<int>({1, 2})).addAll({3, 4}),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('MapBase subclass that only overrides []=/remove/clear throws', () {
+      final rx = RxMap<String, int>(
+        NaiveUnmodifiableMap<String, int>({'a': 1}),
+      );
+
+      expect(() => rx['b'] = 2, throwsUnsupportedError);
+      expect(rx, {'a': 1});
+
+      expect(
+        () => RxMap<String, int>(
+          NaiveUnmodifiableMap<String, int>({'a': 1}),
+        ).clear(),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => RxMap<String, int>(
+          NaiveUnmodifiableMap<String, int>({'a': 1}),
+        ).remove('a'),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('a mutable set/map with custom equals and hashCode still works', () {
+      // Nothing hands these callbacks a foreign sentinel value any more, so
+      // they only ever see the caller's own elements.
+      final set = LinkedHashSet<Object>(
+        equals: (a, b) => (a as String) == (b as String),
+        hashCode: (a) => (a as String).length,
+      )..add('ab');
+      final rxSet = RxSet<Object>(set);
+      expect(() => rxSet.add('cd'), returnsNormally);
+      expect(rxSet.length, 2);
+
+      final map = LinkedHashMap<Object, int>(
+        equals: (a, b) => (a as String) == (b as String),
+        hashCode: (a) => (a as String).length,
+      )..['ab'] = 1;
+      final rxMap = RxMap<Object, int>(map);
+      expect(() => rxMap['cde'] = 2, returnsNormally);
+      expect(rxMap.length, 2);
+
+      final sorted = SplayTreeSet<Object>(
+        (a, b) => (a as String).compareTo(b as String),
+      )..add('ab');
+      final rxSorted = RxSet<Object>(sorted);
+      expect(() => rxSorted.add('cd'), returnsNormally);
+      expect(rxSorted, ['ab', 'cd']);
+    });
+  });
+
+  group('exactly one notification even with a re-entrant listener', () {
+    /// Mutates [rx] with a listener attached that reassigns `value` the first
+    /// time it runs, and reports how many notifications the mutation produced.
+    int notificationsFor(
+      dynamic rx,
+      void Function() mutate,
+      void Function() reassign,
+    ) {
+      var count = 0;
+      var reassigned = false;
+      rx.addListener(() {
+        count++;
+        if (!reassigned) {
+          reassigned = true;
+          reassign();
+        }
+      });
+      mutate();
+      return count;
+    }
+
+    test('RxList heal path matches the in-place path', () {
+      final growable = RxList<int>(<int>[]);
+      final inPlace = notificationsFor(
+        growable,
+        () => growable.add(1),
+        () => growable.value = <int>[99],
+      );
+
+      final fixed = RxList<int>(List<int>.empty());
+      final healPath = notificationsFor(
+        fixed,
+        () => fixed.add(1),
+        () => fixed.value = <int>[99],
+      );
+
+      expect(healPath, inPlace);
+    });
+
+    test('RxList: an unmodifiable backing notifies zero times', () {
+      final frozen = RxList<int>(List<int>.unmodifiable(<int>[]));
+      var count = 0;
+      frozen.addListener(() => count++);
+
+      expect(() => frozen.add(1), throwsUnsupportedError);
+      expect(count, 0);
+      expect(frozen, isEmpty);
+    });
+
+    test('RxSet: an unmodifiable backing notifies zero times', () {
+      final frozen = RxSet<int>(Set<int>.unmodifiable(<int>{}));
+      var count = 0;
+      frozen.addListener(() => count++);
+
+      expect(() => frozen.add(1), throwsUnsupportedError);
+      expect(count, 0);
+      expect(frozen, isEmpty);
+    });
+
+    test('RxMap: an unmodifiable backing notifies zero times', () {
+      final frozen = RxMap<String, int>(
+        Map<String, int>.unmodifiable(<String, int>{}),
+      );
+      var count = 0;
+      frozen.addListener(() => count++);
+
+      expect(() => frozen['a'] = 1, throwsUnsupportedError);
+      expect(count, 0);
+      expect(frozen, isEmpty);
+    });
+  });
+
+  group('element writes on an EMPTY backing follow the aliasing contract', () {
+    test('an empty fixed-length backing is kept, exactly as a seeded one', () {
+      final list = RxList<int>(List<int>.empty());
+      final backing = list.value;
+
+      list.sort();
+      list.shuffle();
+      list.fillRange(0, 0, 0);
+      list.setAll(0, const <int>[]);
+      list.setRange(0, 0, const <int>[]);
+
+      expect(
+        identical(list.value, backing),
+        isTrue,
+        reason:
+            'dart:core performs all of these in place on List.empty(), so '
+            'they must not detach the backing any more than sort() does on a '
+            'non-empty fixed-length list',
+      );
+    });
+
+    test('an empty unmodifiable backing throws instead of being replaced', () {
+      for (final backing in <List<int>>[
+        const <int>[],
+        List<int>.unmodifiable(const <int>[]),
+        UnmodifiableListView<int>(<int>[]),
+      ]) {
+        final list = RxList<int>(backing);
+        var notifications = 0;
+        list.addListener(() => notifications++);
+
+        expect(() => list.sort(), throwsUnsupportedError);
+        expect(
+          () => list.setRange(0, 0, const <int>[]),
+          throwsUnsupportedError,
+        );
+        expect(identical(list.value, backing), isTrue);
+        expect(notifications, 0);
+
+        // `shuffle` is the exception, and deliberately so: with fewer than
+        // two elements it has nothing to swap, so it returns without asking
+        // the backing to write — which is what the inherited
+        // `ListMixin.shuffle` did before RxList overrode it. It still emits
+        // this override's single notification.
+        expect(() => list.shuffle(), returnsNormally);
+        expect(identical(list.value, backing), isTrue);
+        expect(notifications, 1);
+      }
+    });
+
+    test('a length change on an empty fixed-length backing still detaches', () {
+      final list = RxList<int>(List<int>.empty());
+      final backing = list.value;
+
+      list.add(1);
+
+      expect(identical(list.value, backing), isFalse);
+      expect(list, [1]);
+    });
+  });
+
+  group('the aliasing contract is path dependent, and documented as such', () {
+    test('element writes reach a fixed-length backing until it detaches', () {
+      final backing = List<int>.filled(4, 0)..setAll(0, [3, 1, 2, 0]);
+      final list = RxList<int>(backing);
+
+      list[0] = 9;
+      expect(backing, [9, 1, 2, 0], reason: 'element writes go through');
+
+      list.sort();
+      expect(backing, [0, 1, 2, 9], reason: 'so does sort');
+
+      // The documented cliff edge: a length change cannot be done in place, so
+      // from here on the RxList owns a growable copy.
+      list.add(7);
+      expect(identical(list.value, backing), isFalse);
+      expect(backing, [0, 1, 2, 9], reason: 'the caller keeps its buffer');
+      expect(list, [0, 1, 2, 9, 7]);
+
+      list[0] = 42;
+      expect(backing, [0, 1, 2, 9], reason: 'later writes no longer land');
+      expect(list, [42, 1, 2, 9, 7]);
+    });
+
+    test('an unmodifiable backing never detaches, because nothing heals', () {
+      final backing = List<int>.unmodifiable([3, 1, 2]);
+      final list = RxList<int>(backing);
+
+      expect(() => list[0] = 9, throwsUnsupportedError);
+      expect(() => list.sort(), throwsUnsupportedError);
+      expect(() => list.add(7), throwsUnsupportedError);
+
+      expect(identical(list.value, backing), isTrue);
+      expect(list, [3, 1, 2]);
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces a robust "self-healing" mechanism to the `RxList`, `RxMap`, and `RxSet` classes, ensuring that all reactive collections are always mutable, regardless of the mutability of their original backing collections. If a mutation is attempted on an unmodifiable or fixed-length collection, the Rx wrapper transparently replaces the backing with a mutable copy and applies the mutation, notifying listeners exactly once. This change improves developer ergonomics and makes the behavior of reactive collections more predictable and resilient.

The most important changes are:

#### Self-healing mutability for Rx collections

* **RxList**: All mutating methods now check if the backing list can be mutated (either in length or in-place), and if not, a growable copy is created and used instead. This applies to all mutations, including `add`, `remove`, `insert`, `[]=` and more. Detailed documentation is added to clarify the behavior and consequences for maintainers. [[1]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eR4-R49) [[2]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eL35-R180) [[3]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eL64-R281) [[4]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eL179-R309)
* **RxMap**: All mutating methods now check if the backing map can be mutated, and if not, a mutable copy is created and used. This includes methods like `[]=` (assignment), `clear`, `remove`, `addAll`, `putIfAbsent`, `update`, and `updateAll`. Documentation is updated to reflect this behavior. [[1]](diffhunk://#diff-f4c196f37de535c5a412542c33057b59435ffb2f3f3ec1836f364a896cabce00R4-R9) [[2]](diffhunk://#diff-f4c196f37de535c5a412542c33057b59435ffb2f3f3ec1836f364a896cabce00L17-R28) [[3]](diffhunk://#diff-f4c196f37de535c5a412542c33057b59435ffb2f3f3ec1836f364a896cabce00R57-R170)
* **RxSet**: All mutating methods now check if the backing set can be mutated, and if not, a mutable copy is created and used. This includes methods like `add`, `remove`, `addAll`, and `update`. Documentation is updated to explain the behavior. [[1]](diffhunk://#diff-b822fd18f8d016425e561e7dfc9d6d5610160ceddf513d38f08421406240bef0R4-R9) [[2]](diffhunk://#diff-b822fd18f8d016425e561e7dfc9d6d5610160ceddf513d38f08421406240bef0L17-R28) [[3]](diffhunk://#diff-b822fd18f8d016425e561e7dfc9d6d5610160ceddf513d38f08421406240bef0R38-R118)

#### Improved documentation and maintainability

* All three classes now have expanded documentation explaining the self-healing mechanism, its consequences, and guidance for maintainers to avoid accidental regressions or unnecessary optimizations. [[1]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eR4-R49) [[2]](diffhunk://#diff-f4c196f37de535c5a412542c33057b59435ffb2f3f3ec1836f364a896cabce00R4-R9) [[3]](diffhunk://#diff-b822fd18f8d016425e561e7dfc9d6d5610160ceddf513d38f08421406240bef0R4-R9)

#### Notification semantics

* All mutations now ensure listeners are notified exactly once, even if the backing collection is replaced, and conditional notification logic is preserved for operations like `putIfAbsent` and `add`. [[1]](diffhunk://#diff-667a1ec4f3d1dc1a7f312b6fe3f80b6bea0242237002d3e58c14488d352d385eL35-R180) [[2]](diffhunk://#diff-f4c196f37de535c5a412542c33057b59435ffb2f3f3ec1836f364a896cabce00R57-R170) [[3]](diffhunk://#diff-b822fd18f8d016425e561e7dfc9d6d5610160ceddf513d38f08421406240bef0R38-R118)

These changes make the reactive collection types more robust, predictable, and user-friendly, especially when dealing with collections of uncertain mutability.